### PR TITLE
[Refactor/#42] 1차 리펙토링

### DIFF
--- a/my-project/.env
+++ b/my-project/.env
@@ -1,1 +1,2 @@
-VITE_DID_API_KEY=dG53bHM1NjIxNzRAZ21haWwuY29t:HY93xhps-lEQjqGbyNBGj
+VITE_API_BASE_URL=http://localhost:8000
+

--- a/my-project/src/api/axiosInstance.ts
+++ b/my-project/src/api/axiosInstance.ts
@@ -1,0 +1,17 @@
+import axios from "axios";
+
+const BASE_URL = import.meta.env.VITE_API_BASE_URL || "http://localhost:8000";
+
+const axiosInstance = axios.create({
+  baseURL: BASE_URL,
+});
+
+// 요청 인터셉터: 요청을 보낼 때 `Content-Type`을 동적으로 설정
+axiosInstance.interceptors.request.use((config) => {
+  if (!config.headers["Content-Type"]) {
+    config.headers["Content-Type"] = "application/json"; // 기본값은 JSON
+  }
+  return config;
+});
+
+export default axiosInstance;

--- a/my-project/src/api/resumeAPI.ts
+++ b/my-project/src/api/resumeAPI.ts
@@ -1,0 +1,25 @@
+import axiosInstance from "./axiosInstance";
+
+// 이력서 업로드 API
+export const uploadResume = async (file: File) => {
+  const formData = new FormData();
+  formData.append("file", file);
+
+  const response = await axiosInstance.post(`/upload/1`, formData, {
+    headers: {
+      "Content-Type": "multipart/form-data",
+    },
+  });
+
+  return response;
+};
+
+// 면접 시작 API
+export const startInterview = async () => {
+  const response = await axiosInstance.post("/api/apps/start", {
+    user_id: 1,
+    question_count: 3,
+  });
+
+  return response.data;
+};

--- a/my-project/src/api/resumeAPI.ts
+++ b/my-project/src/api/resumeAPI.ts
@@ -5,7 +5,7 @@ export const uploadResume = async (file: File) => {
   const formData = new FormData();
   formData.append("file", file);
 
-  const response = await axiosInstance.post(`/upload/1`, formData, {
+  const response = await axiosInstance.post(`/resumes/upload/1`, formData, {
     headers: {
       "Content-Type": "multipart/form-data",
     },

--- a/my-project/src/components/StartPageContent.tsx
+++ b/my-project/src/components/StartPageContent.tsx
@@ -1,0 +1,62 @@
+import { IMAGES } from "../utils/constants";
+
+interface StartPageContentProps {
+  handleStartClick: () => void;
+}
+
+const StartPageContent = ({ handleStartClick }: StartPageContentProps) => {
+  return (
+    <main className="flex flex-1 items-center justify-center px-16 ">
+      {/* 좌측 텍스트 & 버튼 */}
+      <div className="w-1/2 space-y-4">
+        <p className="text-3xl font-museo text-gray-700 font-semibold">
+          내가 주인공인 순간, 시작은 여기에서!
+        </p>
+        <h2 className="text-5xl font-museo font-bold tracking-normal leading-[1.5]">
+          맞춤형 피드백과 <br /> 전문적인 분석으로 <br /> 나만의 이야기를
+          완성하는
+        </h2>
+        <h2 className="text-5xl font-museo font-bold bg-gradient-to-b from-[#312594] via-[#4F41CE] to-[#8072F8] text-transparent bg-clip-text tracking-wide">
+          AI 모의면접 서비스
+        </h2>
+
+        <button
+          className="px-8 py-3 font-museo text-lg font-semibold text-white bg-indigo-600 rounded-md hover:bg-indigo-700 tracking-widest relative top-4"
+          onClick={handleStartClick}
+        >
+          면접 시작하기
+        </button>
+      </div>
+
+      {/* 우측 이미지 */}
+      <div className="relative w-1/2 h-[500px]">
+        {/* 보라색 모형 */}
+        <div className="fixed w-[810px] h-[380px] bg-gradient-to-b from-[#6859ED] to-[#FF94D6] rounded-l-full top-60 right-0 opacity-80 z-0"></div>
+
+        {/* 이미지들 */}
+        <img
+          src={IMAGES.book}
+          alt="Book"
+          className="fixed w-32 bottom-40 right-80 animate-float"
+        />
+        <img
+          src={IMAGES.flyingBusinessman}
+          alt="Flying Businessman"
+          className="fixed w-1/3 top-60 right-96 animate-float-slow"
+        />
+        <img
+          src={IMAGES.flyingBusinesswoman}
+          alt="Flying Businesswoman"
+          className="fixed w-80 bottom-40 right-0 animate-float-fast"
+        />
+        <img
+          src={IMAGES.robot}
+          alt="Robot"
+          className="fixed w-32 top-50 right-40 animate-float-fast"
+        />
+      </div>
+    </main>
+  );
+};
+
+export default StartPageContent;

--- a/my-project/src/components/WebcamFeed.tsx
+++ b/my-project/src/components/WebcamFeed.tsx
@@ -1,6 +1,6 @@
-import React, { useEffect, useRef } from "react";
+import { useEffect, useRef } from "react";
 
-const WebcamFeed: React.FC = () => {
+const WebcamFeed = () => {
   const videoRef = useRef<HTMLVideoElement>(null);
 
   useEffect(() => {
@@ -23,6 +23,7 @@ const WebcamFeed: React.FC = () => {
     // 컴포넌트 언마운트 시 스트림 정지
     return () => {
       if (videoRef.current && videoRef.current.srcObject) {
+        // eslint-disable-next-line react-hooks/exhaustive-deps
         const tracks = (videoRef.current.srcObject as MediaStream).getTracks();
         tracks.forEach((track) => track.stop());
       }

--- a/my-project/src/components/headers/Header_login.tsx
+++ b/my-project/src/components/headers/Header_login.tsx
@@ -1,18 +1,15 @@
-import { useNavigate } from "react-router-dom"; // 페이지 이동용
+import useNavigation from "../../hooks/useNavigation";
 
 const Header_login = () => {
-  const navigate = useNavigate(); // navigate 훅 사용
-  const handleLogoClick = () => {
-    console.log("메인페이지로 이동");
-    navigate("/"); // state에 memberId 전달
-  };
+  const { goToHome } = useNavigation();
+
   return (
     <div>
       {/* 헤더 */}
       <header className="flex items-center justify-between px-8 py-4 bg-white shadow-md">
         <button
           className="text-3xl font-bold font-museo bg-gradient-to-b from-[#AAA0FF] via-[#4C40B5] to-[#2A1E95] text-transparent bg-clip-text"
-          onClick={() => handleLogoClick()} // 클릭 이벤트 핸들러
+          onClick={goToHome} // 클릭 이벤트 핸들러
         >
           IntelliView
         </button>

--- a/my-project/src/components/headers/InterviewHeader.tsx
+++ b/my-project/src/components/headers/InterviewHeader.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from "react";
 import { ArrowLeft } from "lucide-react"; // 뒤로가기 아이콘
-import Record from "../assets/Record.svg"; // 녹화 아이콘 경로
+import Record from "../../assets/Record.svg"; // 녹화 아이콘 경로
 import { useNavigate } from "react-router-dom"; // 페이지 이동용import axios from "axios"; // axios 추가
 import axios from "axios";
 

--- a/my-project/src/components/headers/InterviewHeader.tsx
+++ b/my-project/src/components/headers/InterviewHeader.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from "react";
 import { ArrowLeft } from "lucide-react"; // 뒤로가기 아이콘
-import Record from "../../assets/Record.svg"; // 녹화 아이콘 경로
+import { IMAGES } from "../../utils/constants";
+
 import { useNavigate } from "react-router-dom"; // 페이지 이동용import axios from "axios"; // axios 추가
 import axios from "axios";
 
@@ -124,7 +125,7 @@ const InterviewHeader = ({
 
       {/* 녹화 타이머 */}
       <div className="flex-1 flex justify-center items-center">
-        <img src={Record} alt="녹화 중" className="w-5 h-5 mr-2" />
+        <img src={IMAGES.Record} alt="녹화 중" className="w-5 h-5 mr-2" />
         <span className="font-bold text-xl font-museo text-black">
           {formatTime(timer)}
         </span>

--- a/my-project/src/components/headers/InterviewHeader.tsx
+++ b/my-project/src/components/headers/InterviewHeader.tsx
@@ -1,15 +1,14 @@
-import React, { useEffect, useState } from "react";
-import { ArrowLeft } from "lucide-react"; // 뒤로가기 아이콘
+import { ArrowLeft } from "lucide-react";
+import { useNavigate } from "react-router-dom";
+import useTimer from "../../hooks/useTimer";
+import useUploadInterviewVideo from "../../hooks/useUploadInterviewVideo";
 import { IMAGES } from "../../utils/constants";
 
-import { useNavigate } from "react-router-dom"; // 페이지 이동용import axios from "axios"; // axios 추가
-import axios from "axios";
-
 interface InterviewHeaderProps {
-  socket: WebSocket | null; // 웹소켓을 부모(InterviewPage)에서 전달받음
+  socket: WebSocket | null;
   interviewId: number;
   stopVideoRecording: () => void;
-  videoChunksRef: React.RefObject<Blob[]>; // ✅ videoChunksRef 추가
+  videoChunksRef: React.RefObject<Blob[]>;
 }
 
 const InterviewHeader = ({
@@ -18,127 +17,41 @@ const InterviewHeader = ({
   stopVideoRecording,
   videoChunksRef,
 }: InterviewHeaderProps) => {
-  const [timer, setTimer] = useState(0); // 타이머 상태
-  const [uploading, setUploading] = useState(false); // ✅ 업로드 상태 추가
   const navigate = useNavigate();
+  const { timer, formatTime } = useTimer();
 
-  // 타이머 증가 로직
-  useEffect(() => {
-    const interval = setInterval(() => {
-      setTimer((prev) => prev + 1);
-    }, 1000);
-
-    return () => clearInterval(interval); // 컴포넌트 언마운트 시 타이머 정지
-  }, []);
-
-  // 초를 분:초 형식으로 변환
-  const formatTime = (seconds: number) => {
-    const minutes = Math.floor(seconds / 60)
-      .toString()
-      .padStart(2, "0");
-    const secs = (seconds % 60).toString().padStart(2, "0");
-    return `${minutes}:${secs}`;
-  };
-  const handleMainPageClick = () => {
-    console.log("메인페이지로 이동");
-
-    navigate("/"); // state에 memberId 전달해야 함.(추후)
-  };
-
-  // ✅ 면접 종료 (웹소켓 종료 & 결과 페이지 이동 & 영상 업로드)
-  const handleEndInterview = async () => {
-    console.log("🛑 면접 종료 버튼 클릭됨");
-    setUploading(true); // 업로드 중 상태 변경
-
-    // 🎥 영상 녹화 중지
-    stopVideoRecording();
-
-    // 🔌 웹소켓 종료
-    if (socket && socket.readyState === WebSocket.OPEN) {
-      socket.close();
-      console.log("🔌 웹소켓 연결 종료됨.");
-    }
-    // ✅ 녹화 종료 후 업로드 실행 (setTimeout 사용)
-    setTimeout(async () => {
-      console.log("🎥 녹화 종료 대기 중...");
-
-      // 🎥 녹화 데이터가 있는지 확인 (비동기 대기)
-      let waitTime = 0;
-      while (
-        (!videoChunksRef.current || videoChunksRef.current.length === 0) &&
-        waitTime < 5000 // 최대 5초 대기
-      ) {
-        await new Promise((resolve) => setTimeout(resolve, 500));
-        waitTime += 500;
-      }
-
-      if (!videoChunksRef.current || videoChunksRef.current.length === 0) {
-        console.error("❌ 녹화된 영상이 없습니다.");
-        setUploading(false); // 업로드 실패 시 다시 원래 상태로
-        return;
-      }
-
-      console.log("✅ 녹화 완료, 영상 업로드 시작");
-
-      // 📂 영상 데이터를 `Blob`으로 변환
-      const videoBlob = new Blob(videoChunksRef.current, {
-        type: "video/webm",
-      });
-
-      // 📂 FormData 생성
-      const formData = new FormData();
-      formData.append("file", videoBlob, "interviewVideo.webm");
-
-      try {
-        const response = await axios.post(
-          `http://localhost:8000/results/upload/${interviewId}`,
-          formData,
-          {
-            headers: { "Content-Type": "multipart/form-data" },
-          }
-        );
-
-        if (response.status === 201) {
-          console.log("✅ 면접 영상 업로드 성공!");
-          navigate("/report", { state: { interviewId } });
-        } else {
-          console.error("❌ 업로드 실패!", response);
-          setUploading(false); // 업로드 실패 시 원래 상태로 복구
-        }
-      } catch (error) {
-        console.error("❌ 업로드 중 오류 발생:", error);
-        setUploading(false);
-      }
-    }, 1000); // 1초 딜레이 후 녹화 확인 및 업로드 진행
-  };
+  const { uploading, uploadVideo } = useUploadInterviewVideo(
+    videoChunksRef,
+    interviewId,
+    stopVideoRecording,
+    socket
+  );
 
   return (
     <header className="flex items-center justify-between px-4 py-4 bg-gray-400 bg-opacity-20 backdrop-blur-md shadow-sm fixed top-0 w-full z-10">
-      {/* 돌아가기 버튼 */}
       <button
-        className="flex items-center text-white text-m font-medium px-5 py-2  bg-gray-300 bg-opacity-60 rounded-md hover:bg-gray-200 transition ml-2"
-        onClick={() => handleMainPageClick()} // 클릭 이벤트 핸들러
+        className="flex items-center text-white text-m font-medium px-5 py-2 bg-gray-300 bg-opacity-60 rounded-md hover:bg-gray-200 transition ml-2"
+        onClick={() => navigate("/")}
       >
         <ArrowLeft className="w-6 h-6 mr-1" />
         메인으로
       </button>
 
-      {/* 녹화 타이머 */}
       <div className="flex-1 flex justify-center items-center">
         <img src={IMAGES.Record} alt="녹화 중" className="w-5 h-5 mr-2" />
         <span className="font-bold text-xl font-museo text-black">
           {formatTime(timer)}
         </span>
       </div>
-      {/* ✅ 면접 종료 버튼 (오른쪽에 추가) */}
+
       <button
         className={`flex items-center text-white text-m font-medium px-5 py-2 rounded-md transition ml-2 ${
           uploading
             ? "bg-gray-500 cursor-not-allowed"
             : "bg-red-500 hover:bg-red-600"
         }`}
-        onClick={handleEndInterview}
-        disabled={uploading} // 업로드 중 버튼 비활성화
+        onClick={uploadVideo}
+        disabled={uploading}
       >
         {uploading ? "면접영상 업로드 중..." : "면접 종료"}
       </button>

--- a/my-project/src/components/modals/Modal.tsx
+++ b/my-project/src/components/modals/Modal.tsx
@@ -1,47 +1,59 @@
-import React from "react";
+import { useEffect, ReactNode } from "react";
 
-// Modal 컴포넌트의 props 인터페이스 정의
 interface ModalProps {
-  isOpen: boolean; // 모달 열림 여부
-  onClose: () => void; // 모달 닫기 핸들러
-  children: React.ReactNode; // 모달 내부에 렌더링할 콘텐츠
+  isOpen: boolean;
+  onClose: () => void;
+  children: ReactNode;
+  width?: string;
+  height?: string;
+  rounded?: string;
 }
 
-// Modal 컴포넌트 정의
-const Modal: React.FC<ModalProps> = ({ isOpen, onClose, children }) => {
-  if (!isOpen) {
-    return null;
-  }
-
-  // 모달 배경 클릭 핸들러: 배경을 클릭하면 모달 닫기
-  const handleBackgroundClick = (event: React.MouseEvent<HTMLDivElement>) => {
-    if (event.target === event.currentTarget) {
-      onClose(); // 배경 클릭 시 onClose 콜백 호출
+function Modal({
+  isOpen,
+  onClose,
+  children,
+  width = "w-120",
+  height = "h-120",
+  rounded = "rounded-3xl",
+}: ModalProps) {
+  // ESC 키로 모달 닫기 기능 추가
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        onClose();
+      }
+    };
+    if (isOpen) {
+      document.addEventListener("keydown", handleKeyDown);
     }
-  };
+    return () => {
+      document.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [isOpen, onClose]);
+
+  if (!isOpen) return null;
 
   return (
-    // 모달 배경 (회색 반투명 레이어)
     <div
       className="fixed inset-0 bg-gray-600 bg-opacity-75 flex items-center justify-center z-[9999]"
-      onClick={handleBackgroundClick} // 배경 클릭 핸들러 설정
+      onClick={(e) => e.target === e.currentTarget && onClose()}
     >
-      {/* 모달 콘텐츠 */}
       <div
-        className="bg-white p-8 rounded-3xl w-120 h-120 text-center relative"
-        onClick={(e) => e.stopPropagation()} // 클릭 이벤트 전파 중단 (배경 클릭과 구분)
+        className={`bg-white p-8 ${rounded} ${width} ${height} text-center relative`}
+        onClick={(e) => e.stopPropagation()}
       >
         {/* 닫기 버튼 */}
         <button
           onClick={onClose}
-          className="absolute top-2 right-4  text-gray-400 hover:text-gray-600 text-2xl"
+          className="absolute top-2 right-4 text-gray-400 hover:text-gray-600 text-2xl"
         >
           &times;
         </button>
-        {children} {/* 모달 내부에 렌더링될 콘텐츠 */}
+        {children}
       </div>
     </div>
   );
-};
+}
 
 export default Modal;

--- a/my-project/src/components/modals/ResumeUploadModal.tsx
+++ b/my-project/src/components/modals/ResumeUploadModal.tsx
@@ -1,8 +1,6 @@
-import { useState } from "react";
-import axios from "axios";
 import Modal from "./Modal";
-import Man from "../../assets/Man.svg";
-import { useNavigate } from "react-router-dom"; // 페이지 이동용
+import { IMAGES } from "../../utils/constants";
+import useResumeUpload from "../../hooks/useResumeUpload";
 
 interface ResumeUploadModalProps {
   isOpen: boolean;
@@ -10,89 +8,20 @@ interface ResumeUploadModalProps {
 }
 
 const ResumeUploadModal = ({ isOpen, onClose }: ResumeUploadModalProps) => {
-  const [file, setFile] = useState<File | null>(null);
-  const [uploading, setUploading] = useState(false);
-  const [uploadCompleted, setUploadCompleted] = useState(false); // 업로드 완료 여부
-  const navigate = useNavigate();
-
-  // 파일 선택 핸들러
-  const handleFileChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-    if (event.target.files && event.target.files.length > 0) {
-      setFile(event.target.files[0]);
-    }
-  };
-
-  const handleUploadResume = async () => {
-    if (!file) {
-      alert("파일을 선택해주세요.");
-      return;
-    }
-
-    const formData = new FormData();
-    formData.append("file", file);
-
-    setUploading(true);
-
-    try {
-      const response = await axios.post(
-        `http://localhost:8000/resumes/upload/1`,
-        formData,
-        {
-          headers: {
-            "Content-Type": "multipart/form-data",
-          },
-        }
-      );
-
-      if (response.status === 201) {
-        alert("이력서가 성공적으로 업로드되었습니다!");
-        setUploadCompleted(true); // 업로드 완료 상태 변경
-      } else {
-        alert("업로드 실패! 다시 시도해주세요.");
-      }
-    } catch (error) {
-      console.error("Error uploading resume:", error);
-      alert("업로드 중 오류가 발생했습니다.");
-    } finally {
-      setUploading(false);
-    }
-  };
-
-  const handleStartInterviewClick = async () => {
-    if (!uploadCompleted) return; // 업로드 완료되지 않으면 실행 안 됨
-
-    console.log("면접페이지로 이동");
-
-    try {
-      const response = await axios.post(
-        "http://localhost:8000/api/apps/start",
-        {
-          user_id: 1,
-          question_count: 3,
-        }
-      );
-
-      if (response.status === 201 && response.data?.interview_id) {
-        const interviewId = response.data.interview_id;
-        console.log("서버 응답:", response.data.message);
-        console.log("면접 ID:", response.data.interview_id);
-        console.log("질문 개수:", response.data.questions_count);
-
-        onClose(); // 면접 시작 시에만 모달 닫기
-        navigate("/interview", { state: { interviewId } });
-      } else {
-        console.error("❌ 면접 시작 실패! 응답 값 없음:", response);
-      }
-    } catch (error) {
-      console.error("❌ 면접 시작 API 오류:", error);
-    }
-  };
+  const {
+    file,
+    uploading,
+    uploadCompleted,
+    handleFileChange,
+    handleUploadResume,
+    handleStartInterviewClick,
+  } = useResumeUpload(onClose);
 
   return (
     <Modal isOpen={isOpen} onClose={onClose}>
       <div className="text-center font-museo relative">
         <img
-          src={Man}
+          src={IMAGES.Man}
           alt="Avatar"
           className="w-32 h-32 mx-auto mt-5 rounded-full border-gray-300 mb-4"
         />
@@ -110,6 +39,12 @@ const ResumeUploadModal = ({ isOpen, onClose }: ResumeUploadModalProps) => {
         {/* 파일 선택 및 이력서 업로드 버튼을 같은 줄에 배치 */}
         <div className="flex justify-center gap-4 mt-4">
           {/* 파일 선택 버튼 */}
+          <input
+            type="file"
+            id="fileInput"
+            style={{ display: "none" }}
+            onChange={handleFileChange}
+          />
           <label
             htmlFor="fileInput"
             className="bg-indigo-600 rounded-md hover:bg-indigo-700 tracking-widest text-white text-semibold px-6 py-3 transition cursor-pointer"

--- a/my-project/src/hooks/useAudioRecorder.ts
+++ b/my-project/src/hooks/useAudioRecorder.ts
@@ -1,0 +1,69 @@
+// 이 훅이 하는 일
+
+// 1. startRecording() : 마이크 권한 요청 → MediaRecorder로 녹음 시작
+// 2. stopRecording() : 녹음 종료 → 데이터 조각 합치고 서버로 전송
+// 3. sendAudio() : 웹소켓으로 음성 Blob 전송
+// 4. 내부 상태	: mediaRecorderRef, audioChunksRef 로컬 관리, recording은 zustand로 공유
+
+import { useRef } from "react";
+import useInterviewStore from "../store/useInterviewStore";
+
+const useAudioRecorder = () => {
+  const { socket, setRecording } = useInterviewStore();
+  const mediaRecorderRef = useRef<MediaRecorder | null>(null);
+  const audioChunksRef = useRef<Blob[]>([]);
+
+  // 🎤 녹음 시작
+  const startRecording = async () => {
+    try {
+      const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+      const mediaRecorder = new MediaRecorder(stream);
+
+      mediaRecorder.ondataavailable = (event) => {
+        if (event.data.size > 0) {
+          audioChunksRef.current.push(event.data);
+        }
+      };
+
+      mediaRecorder.start();
+      mediaRecorderRef.current = mediaRecorder;
+      setRecording(true);
+      console.log("🎙️ 녹음 시작");
+    } catch (error) {
+      console.error("❌ 마이크 접근 실패:", error);
+    }
+  };
+
+  // ⏹ 녹음 종료 및 서버 전송
+  const stopRecording = () => {
+    if (mediaRecorderRef.current) {
+      mediaRecorderRef.current.stop();
+      mediaRecorderRef.current.onstop = () => {
+        const audioBlob = new Blob(audioChunksRef.current, {
+          type: "audio/webm",
+        });
+        sendAudio(audioBlob);
+        audioChunksRef.current = [];
+      };
+      setRecording(false);
+      console.log("🛑 녹음 종료");
+    }
+  };
+
+  // 📤 서버로 오디오 전송
+  const sendAudio = (audioBlob: Blob) => {
+    if (socket && socket.readyState === WebSocket.OPEN) {
+      socket.send(audioBlob);
+      console.log("📡 음성 전송 완료!");
+    } else {
+      console.error("🚫 웹소켓이 열려있지 않음.");
+    }
+  };
+
+  return {
+    startRecording,
+    stopRecording,
+  };
+};
+
+export default useAudioRecorder;

--- a/my-project/src/hooks/useNavigation.ts
+++ b/my-project/src/hooks/useNavigation.ts
@@ -5,6 +5,8 @@ const useNavigation = () => {
 
   return {
     goToHome: () => navigate("/"),
+    goToInterview: (interviewId: number) =>
+      navigate("/interview", { state: { interviewId } }),
     goToMyPage: () => navigate("/mypage"),
     goToReport: () => navigate("/report"),
   };

--- a/my-project/src/hooks/useNavigation.ts
+++ b/my-project/src/hooks/useNavigation.ts
@@ -1,0 +1,13 @@
+import { useNavigate } from "react-router-dom";
+
+const useNavigation = () => {
+  const navigate = useNavigate();
+
+  return {
+    goToHome: () => navigate("/"),
+    goToMyPage: () => navigate("/mypage"),
+    goToReport: () => navigate("/report"),
+  };
+};
+
+export default useNavigation;

--- a/my-project/src/hooks/useResumeUpload.ts
+++ b/my-project/src/hooks/useResumeUpload.ts
@@ -1,0 +1,64 @@
+import { useState } from "react";
+import { uploadResume, startInterview } from "../api/resumeAPI";
+import useNavigation from "./useNavigation";
+
+const useResumeUpload = (onClose: () => void) => {
+  const [file, setFile] = useState<File | null>(null);
+  const [uploading, setUploading] = useState(false);
+  const [uploadCompleted, setUploadCompleted] = useState(false);
+  const { goToInterview } = useNavigation();
+
+  // 파일 선택 핸들러
+  const handleFileChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    if (event.target.files && event.target.files.length > 0) {
+      setFile(event.target.files[0]);
+    }
+  };
+
+  // 이력서 업로드 핸들러
+  const handleUploadResume = async () => {
+    if (!file) return alert("파일을 선택해주세요.");
+    setUploading(true);
+
+    try {
+      const response = await uploadResume(file);
+      if (response.status === 201) {
+        alert("이력서가 성공적으로 업로드되었습니다!");
+        setUploadCompleted(true);
+      } else {
+        alert("업로드 실패! 다시 시도해주세요.");
+      }
+    } catch (error) {
+      console.error("Error uploading resume:", error);
+      alert("업로드 중 오류가 발생했습니다.");
+    } finally {
+      setUploading(false);
+    }
+  };
+
+  // 면접 시작 핸들러
+  const handleStartInterviewClick = async () => {
+    if (!uploadCompleted) return;
+
+    try {
+      const data = await startInterview();
+      if (data?.interview_id) {
+        goToInterview(data.interview_id);
+        onClose();
+      }
+    } catch (error) {
+      console.error("면접 시작 오류:", error);
+    }
+  };
+
+  return {
+    file,
+    uploading,
+    uploadCompleted,
+    handleFileChange,
+    handleUploadResume,
+    handleStartInterviewClick,
+  };
+};
+
+export default useResumeUpload;

--- a/my-project/src/hooks/useStartPage.ts
+++ b/my-project/src/hooks/useStartPage.ts
@@ -1,0 +1,13 @@
+//StartPage에서 사용되는 훅
+
+//openUploadingModal 핸들러
+const useStartPage = (openUploadingModal: () => void) => {
+  const handleStartClick = () => {
+    console.log("모달 열기 버튼 클릭됨");
+    openUploadingModal();
+  };
+
+  return { handleStartClick };
+};
+
+export default useStartPage;

--- a/my-project/src/hooks/useTimer.ts
+++ b/my-project/src/hooks/useTimer.ts
@@ -1,0 +1,24 @@
+// src/hooks/useTimer.ts
+// 면접 페이지에서 헤더에 나타나는 타이머
+import { useEffect, useState } from "react";
+
+const useTimer = () => {
+  const [timer, setTimer] = useState(0);
+
+  useEffect(() => {
+    const interval = setInterval(() => setTimer((prev) => prev + 1), 1000);
+    return () => clearInterval(interval);
+  }, []);
+
+  const formatTime = (seconds: number) => {
+    const minutes = Math.floor(seconds / 60)
+      .toString()
+      .padStart(2, "0");
+    const secs = (seconds % 60).toString().padStart(2, "0");
+    return `${minutes}:${secs}`;
+  };
+
+  return { timer, formatTime };
+};
+
+export default useTimer;

--- a/my-project/src/hooks/useUploadInterviewVideo.ts
+++ b/my-project/src/hooks/useUploadInterviewVideo.ts
@@ -1,0 +1,75 @@
+// src/hooks/useUploadInterviewVideo.ts
+//  영상 업로드 로직
+import { useState } from "react";
+import { useNavigate } from "react-router-dom";
+import axiosInstance from "../api/axiosInstance"; // ← 전역 인스턴스 사용
+// import { InterviewId } from "../types"; // 필요시 타입 분리
+
+const useUploadInterviewVideo = (
+  videoChunksRef: React.RefObject<Blob[]>,
+  interviewId: number,
+  stopVideoRecording: () => void,
+  socket: WebSocket | null
+) => {
+  const [uploading, setUploading] = useState(false);
+  const navigate = useNavigate();
+
+  const uploadVideo = async () => {
+    console.log("🛑 면접 종료 시도");
+    setUploading(true);
+    stopVideoRecording();
+
+    if (socket && socket.readyState === WebSocket.OPEN) {
+      socket.close();
+      console.log("🔌 웹소켓 연결 종료됨.");
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, 1000)); // 딜레이
+
+    let waitTime = 0;
+    while (
+      (!videoChunksRef.current || videoChunksRef.current.length === 0) &&
+      waitTime < 5000
+    ) {
+      await new Promise((r) => setTimeout(r, 500));
+      waitTime += 500;
+    }
+
+    if (!videoChunksRef.current || videoChunksRef.current.length === 0) {
+      console.error("❌ 녹화된 영상 없음");
+      setUploading(false);
+      return;
+    }
+
+    const videoBlob = new Blob(videoChunksRef.current, {
+      type: "video/webm",
+    });
+    const formData = new FormData();
+    formData.append("file", videoBlob, "interviewVideo.webm");
+
+    try {
+      const res = await axiosInstance.post(
+        `/results/upload/${interviewId}`,
+        formData,
+        {
+          headers: { "Content-Type": "multipart/form-data" },
+        }
+      );
+
+      if (res.status === 201) {
+        console.log("✅ 영상 업로드 성공");
+        navigate("/report", { state: { interviewId } });
+      } else {
+        console.error("❌ 업로드 실패", res);
+      }
+    } catch (err) {
+      console.error("❌ 업로드 중 오류", err);
+    } finally {
+      setUploading(false);
+    }
+  };
+
+  return { uploading, uploadVideo };
+};
+
+export default useUploadInterviewVideo;

--- a/my-project/src/hooks/useVideoRecorder.ts
+++ b/my-project/src/hooks/useVideoRecorder.ts
@@ -5,16 +5,22 @@
 // 3. videoChunksRef : 영상 데이터가 저장된 곳 (녹화 후 저장용으로 사용 가능)
 // 4. Zustand 상태 : videoRecording 상태 전역 관리 (녹화 중인지 여부)
 
-import { useRef } from "react";
+import { useRef, useCallback } from "react";
 import useInterviewStore from "../store/useInterviewStore";
 
 const useVideoRecorder = () => {
-  const { setVideoRecording } = useInterviewStore();
+  const { videoRecording, setVideoRecording } = useInterviewStore();
   const videoMediaRecorderRef = useRef<MediaRecorder | null>(null);
   const videoChunksRef = useRef<Blob[]>([]);
 
   // 🎥 녹화 시작
-  const startVideoRecording = async () => {
+  const startVideoRecording = useCallback(async () => {
+    if (videoRecording) {
+      console.warn("⚠️ 이미 녹화 중입니다! 중복 실행 방지됨.");
+      return;
+    }
+    setVideoRecording(true);
+
     try {
       const stream = await navigator.mediaDevices.getUserMedia({
         video: true,
@@ -38,7 +44,7 @@ const useVideoRecorder = () => {
     } catch (error) {
       console.error("❌ 영상 녹화 시작 실패:", error);
     }
-  };
+  }, [videoRecording, setVideoRecording]);
 
   // ⏹ 녹화 종료
   const stopVideoRecording = () => {
@@ -53,6 +59,7 @@ const useVideoRecorder = () => {
   };
 
   return {
+    videoRecording,
     startVideoRecording,
     stopVideoRecording,
     videoChunksRef, // 필요하다면 부모 컴포넌트로 전달 가능

--- a/my-project/src/hooks/useVideoRecorder.ts
+++ b/my-project/src/hooks/useVideoRecorder.ts
@@ -1,0 +1,62 @@
+// 이 훅이 하는 일
+
+// 1. startVideoRecording() : 사용자의 카메라/마이크 접근 → 영상 녹화 시작
+// 2. stopVideoRecording() : 녹화 중단 + 영상 데이터 준비
+// 3. videoChunksRef : 영상 데이터가 저장된 곳 (녹화 후 저장용으로 사용 가능)
+// 4. Zustand 상태 : videoRecording 상태 전역 관리 (녹화 중인지 여부)
+
+import { useRef } from "react";
+import useInterviewStore from "../store/useInterviewStore";
+
+const useVideoRecorder = () => {
+  const { setVideoRecording } = useInterviewStore();
+  const videoMediaRecorderRef = useRef<MediaRecorder | null>(null);
+  const videoChunksRef = useRef<Blob[]>([]);
+
+  // 🎥 녹화 시작
+  const startVideoRecording = async () => {
+    try {
+      const stream = await navigator.mediaDevices.getUserMedia({
+        video: true,
+        audio: true,
+      });
+
+      const mediaRecorder = new MediaRecorder(stream, {
+        mimeType: "video/webm",
+      });
+
+      mediaRecorder.ondataavailable = (event) => {
+        if (event.data.size > 0) {
+          videoChunksRef.current.push(event.data);
+        }
+      };
+
+      mediaRecorder.start();
+      videoMediaRecorderRef.current = mediaRecorder;
+      setVideoRecording(true);
+      console.log("🎬 영상 녹화 시작");
+    } catch (error) {
+      console.error("❌ 영상 녹화 시작 실패:", error);
+    }
+  };
+
+  // ⏹ 녹화 종료
+  const stopVideoRecording = () => {
+    if (videoMediaRecorderRef.current) {
+      videoMediaRecorderRef.current.stop();
+      videoMediaRecorderRef.current.onstop = () => {
+        console.log("🎞️ 영상 녹화 완료. 저장 준비 완료");
+        // videoChunksRef.current에 녹화된 영상이 있음
+      };
+      setVideoRecording(false);
+    }
+  };
+
+  return {
+    startVideoRecording,
+    stopVideoRecording,
+    videoChunksRef, // 필요하다면 부모 컴포넌트로 전달 가능
+  };
+};
+
+export default useVideoRecorder;

--- a/my-project/src/hooks/useWebSocket.ts
+++ b/my-project/src/hooks/useWebSocket.ts
@@ -1,0 +1,84 @@
+// 이 훅이 하는 일
+// 1. 웹소켓 연결 : interviewId로 웹소켓 자동 연결
+// 2. 메시지 수신 : GPT 질문/음성 수신 시 오디오 재생
+// 3. 가상 면접관 연동 : 음성 재생 시 playVideo(), 종료 시 pauseVideo() 호출
+// 4. 전역 socket 상태 저장 : Zustand에 socket 저장해서 어디서든 접근 가능
+
+import { useEffect } from "react";
+import useInterviewStore from "../store/useInterviewStore";
+
+type VirtualInterviewerRef = React.RefObject<{
+  playVideo: () => void;
+  pauseVideo: () => void;
+}>;
+
+const useWebSocket = (
+  virtualInterviewerRef: VirtualInterviewerRef,
+  currentAudioRef: React.MutableRefObject<HTMLAudioElement | null>
+) => {
+  const { interviewId, setSocket } = useInterviewStore();
+
+  useEffect(() => {
+    if (!interviewId) return;
+
+    const ws = new WebSocket(
+      `ws://localhost:8000/ws/interview/${interviewId}/`
+    );
+    setSocket(ws);
+
+    ws.onopen = () => {
+      console.log("✅ 웹소켓 연결 성공!");
+    };
+
+    ws.onmessage = (event) => {
+      console.log("📩 서버 메시지 수신:", event.data);
+
+      try {
+        const data = JSON.parse(event.data);
+
+        if (data.text && data.audio_url) {
+          console.log("🎤 질문:", data.text);
+          console.log("🔊 오디오 URL:", data.audio_url);
+
+          // 기존 오디오가 재생 중이면 정지
+          if (currentAudioRef.current) {
+            currentAudioRef.current.pause();
+            currentAudioRef.current = null;
+          }
+
+          const audio = new Audio(data.audio_url);
+          currentAudioRef.current = audio;
+
+          audio.play().then(() => {
+            virtualInterviewerRef.current?.playVideo();
+          });
+
+          audio.addEventListener("ended", () => {
+            virtualInterviewerRef.current?.pauseVideo();
+            currentAudioRef.current = null;
+          });
+        } else if (data.message) {
+          console.log("💬 시스템 메시지:", data.message);
+        } else {
+          console.warn("⚠️ 알 수 없는 형식:", data);
+        }
+      } catch (err) {
+        console.error("🛑 JSON 파싱 오류:", err);
+      }
+    };
+
+    ws.onerror = (error) => {
+      console.error("❌ 웹소켓 오류:", error);
+    };
+
+    ws.onclose = () => {
+      console.log("🔌 웹소켓 연결 종료");
+    };
+
+    return () => {
+      ws.close(); // 언마운트 시 종료
+    };
+  }, [interviewId, virtualInterviewerRef, currentAudioRef, setSocket]);
+};
+
+export default useWebSocket;

--- a/my-project/src/pages/InterviewPage.tsx
+++ b/my-project/src/pages/InterviewPage.tsx
@@ -1,192 +1,45 @@
-import { useEffect, useState, useRef } from "react";
-import InterviewHeader from "../components/headers/InterviewHeader";
-import "../index.css";
-import { useLocation } from "react-router-dom"; // interview_id 가져오기
+// src/pages/InterviewPage.tsx
+import { useEffect, useRef } from "react";
+import { useLocation } from "react-router-dom";
+import useInterviewStore from "../store/useInterviewStore";
+import useWebSocket from "../hooks/useWebSocket";
+import useAudioRecorder from "../hooks/useAudioRecorder";
+import useVideoRecorder from "../hooks/useVideoRecorder";
 
-import WebcamFeed from "../components/WebcamFeed";
+import InterviewHeader from "../components/headers/InterviewHeader";
 import VirtualInterviewer from "../components/VirtualInterviewer";
+import WebcamFeed from "../components/WebcamFeed";
 
 const InterviewPage = () => {
   const location = useLocation();
-  const interviewId = Number(location.state?.interviewId || null);
-  console.log("면접 ID:", interviewId);
-
-  const [socket, setSocket] = useState<WebSocket | null>(null);
-  // const [messages, setMessages] = useState<string[]>([]);
-  const [recording, setRecording] = useState(false); // 녹음 상태 관리
-  const mediaRecorderRef = useRef<MediaRecorder | null>(null);
   const virtualInterviewerRef = useRef<{
     playVideo: () => void;
     pauseVideo: () => void;
   } | null>(null);
-  // 🔹 컴포넌트 내부에 추가
   const currentAudioRef = useRef<HTMLAudioElement | null>(null);
 
-  const audioChunksRef = useRef<Blob[]>([]);
-  // 🎥 영상 녹화 관련 변수 추가
-  const [, setVideoRecording] = useState(false);
-  const videoMediaRecorderRef = useRef<MediaRecorder | null>(null);
-  const videoChunksRef = useRef<Blob[]>([]);
+  const { interviewId, setInterviewId, recording } = useInterviewStore();
+
+  const { startRecording, stopRecording } = useAudioRecorder();
+  const { startVideoRecording, stopVideoRecording, videoChunksRef } =
+    useVideoRecorder();
+
+  // 면접 ID 설정
   useEffect(() => {
-    startVideoRecording(); // 페이지 진입 시 자동 영상 녹화 시작
-  }, []);
+    const id = Number(location.state?.interviewId || null);
+    setInterviewId(id);
+  }, [location, setInterviewId]);
 
+  // 웹소켓 연결 & 메시지 처리
+  useWebSocket(virtualInterviewerRef, currentAudioRef);
+
+  // 영상 녹화 시작
   useEffect(() => {
-    // 웹소켓 서버 연결
-    const ws = new WebSocket(
-      `ws://localhost:8000/ws/interview/${Number(interviewId)}/`
-    );
-
-    ws.onopen = () => {
-      console.log("웹소켓 연결 성공!");
-      // ws.send(JSON.stringify({ type: "init", message: "InterviewPage 접속" }));
-    };
-
-    ws.onmessage = (event) => {
-      console.log("서버로부터 원본 메시지 수신:", event.data);
-
-      try {
-        const data = JSON.parse(event.data);
-
-        if (data.text && data.audio_url) {
-          // 🧑‍💻 GPT 질문 및 음성 URL 처리
-          console.log("🎤 GPT 질문:", data.text);
-          console.log("🔊 음성 파일 URL:", data.audio_url);
-
-          // 메시지 업데이트
-          // setMessages((prev) => [...prev, data.text]);
-
-          // 음성 자동 재생
-          const audio = new Audio(data.audio_url);
-          currentAudioRef.current = audio;
-
-          audio.play().then(() => {
-            if (virtualInterviewerRef.current) {
-              virtualInterviewerRef.current.playVideo();
-            }
-          });
-
-          audio.addEventListener("ended", () => {
-            if (virtualInterviewerRef.current) {
-              virtualInterviewerRef.current.pauseVideo();
-            }
-            currentAudioRef.current = null;
-          });
-        } else if (data.message) {
-          // 💬 일반적인 시스템 메시지 처리
-          console.log("💡 일반 메시지:", data.message);
-          // setMessages((prev) => [...prev, data.message]);
-        } else {
-          console.warn("⚠️ 서버에서 알 수 없는 데이터 형식 수신:", data);
-        }
-      } catch (error) {
-        console.error("🛑 JSON 파싱 오류:", error);
-      }
-    };
-
-    ws.onclose = () => {
-      console.log("웹소켓 연결 종료");
-    };
-
-    ws.onerror = (error) => {
-      console.error("웹소켓 오류 발생:", error);
-    };
-
-    setSocket(ws);
-
-    return () => {
-      ws.close(); // 페이지 언마운트 시 웹소켓 종료
-    };
-  }, []);
-
-  // 🎤 음성 녹음 시작
-  const startRecording = async () => {
-    try {
-      const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
-      const mediaRecorder = new MediaRecorder(stream);
-
-      mediaRecorder.ondataavailable = (event) => {
-        if (event.data.size > 0) {
-          audioChunksRef.current.push(event.data);
-        }
-      };
-
-      mediaRecorder.start();
-      mediaRecorderRef.current = mediaRecorder;
-      setRecording(true);
-      console.log("녹음 시작!");
-    } catch (error) {
-      console.error("마이크 접근 실패:", error);
-    }
-  };
-
-  // ⏹ 녹음 종료 및 서버로 전송
-  const stopRecording = () => {
-    if (mediaRecorderRef.current) {
-      mediaRecorderRef.current.stop();
-      mediaRecorderRef.current.onstop = () => {
-        const audioBlob = new Blob(audioChunksRef.current, {
-          type: "audio/webm",
-        });
-        sendAudio(audioBlob);
-        audioChunksRef.current = []; // 녹음 데이터 초기화
-      };
-      setRecording(false);
-      console.log("녹음 종료 및 서버로 전송");
-    }
-  };
-
-  // 📤 웹소켓을 통해 서버로 음성 데이터 전송 (웹소켓 종료 없이)
-  const sendAudio = (audioBlob: Blob) => {
-    if (socket && socket.readyState === WebSocket.OPEN) {
-      socket.send(audioBlob);
-      console.log("🎤 음성 메시지 데이터 서버로 전송 완료!");
-    } else {
-      console.error("❌ 웹소켓이 연결되지 않았습니다.");
-    }
-  };
-
-  // 🎥 영상 녹화 시작 함수
-  const startVideoRecording = async () => {
-    try {
-      const stream = await navigator.mediaDevices.getUserMedia({
-        video: true,
-        audio: true,
-      });
-
-      const mediaRecorder = new MediaRecorder(stream, {
-        mimeType: "video/webm",
-      });
-
-      mediaRecorder.ondataavailable = (event) => {
-        if (event.data.size > 0) {
-          videoChunksRef.current.push(event.data);
-        }
-      };
-
-      mediaRecorder.start();
-      videoMediaRecorderRef.current = mediaRecorder;
-      setVideoRecording(true);
-      console.log("🎥 영상 녹화 시작!");
-    } catch (error) {
-      console.error("🎥 영상 녹화 시작 실패:", error);
-    }
-  };
-
-  // 🎥 영상 녹화 중지 함수
-  const stopVideoRecording = () => {
-    if (videoMediaRecorderRef.current) {
-      videoMediaRecorderRef.current.stop();
-      videoMediaRecorderRef.current.onstop = () => {
-        console.log("🎥 녹화 종료됨, 파일 저장 준비");
-      };
-      setVideoRecording(false);
-    }
-  };
+    startVideoRecording();
+  }, [startVideoRecording]);
 
   return (
     <div className="flex flex-col h-screen">
-      {/* Main Content */}
       <div
         style={{
           position: "relative",
@@ -194,32 +47,17 @@ const InterviewPage = () => {
           backgroundColor: "#f4f4f4",
         }}
       >
-        {/* Virtual Interviewer */}
-        <div
-          style={{
-            position: "absolute",
-            top: 0,
-            left: 0,
-            right: 0,
-            bottom: 0,
-          }}
-        >
+        {/* 가상 면접관 */}
+        <div style={{ position: "absolute", inset: 0 }}>
           <VirtualInterviewer ref={virtualInterviewerRef} />
         </div>
 
-        {/* Webcam Feed */}
-        <div
-          style={{
-            position: "fixed",
-            bottom: 20,
-            left: 20,
-            zIndex: 99,
-          }}
-        >
+        {/* 웹캠 */}
+        <div style={{ position: "fixed", bottom: 20, left: 20, zIndex: 99 }}>
           <WebcamFeed />
         </div>
 
-        {/* Interview Header */}
+        {/* 헤더 */}
         <div
           style={{
             position: "absolute",
@@ -229,33 +67,18 @@ const InterviewPage = () => {
             zIndex: 1000,
           }}
         >
-          <InterviewHeader
-            interviewId={interviewId}
-            stopVideoRecording={stopVideoRecording} // 면접 종료 시 영상 녹화도 중지
-            socket={socket} // 웹소켓 연결 정보 전달
-            videoChunksRef={videoChunksRef} // ✅ 녹화된 영상 데이터 전달
-          />
+          {interviewId !== null && (
+            <InterviewHeader
+              interviewId={interviewId}
+              stopVideoRecording={stopVideoRecording}
+              socket={useInterviewStore.getState().socket} // 전역 상태에서 socket 가져오기
+              videoChunksRef={videoChunksRef}
+            />
+          )}
         </div>
 
-        {/* 웹소켓 메시지 표시 */}
-        {/* <div className="fixed bottom-8 left-1/2 transform -translate-x-1/2 bg-black bg-opacity-75 text-white px-5 py-4 rounded-lg text-lg font-bold text-center max-w-4xl leading-relaxed z-50 whitespace-pre-line transition-opacity duration-500">
-          <h4>질문</h4>
-          <ul style={{ fontSize: "18px", color: "#aaa", margin: 0 }}>
-            {messages.map((msg, index) => (
-              <li key={index}>{msg}</li>
-            ))}
-          </ul>{" "}
-        </div> */}
-
-        {/* 🎤 녹음 버튼 */}
-        <div
-          style={{
-            position: "fixed",
-            bottom: 20,
-            right: 20,
-            zIndex: 1100, // 메시지 로그보다 위에 위치
-          }}
-        >
+        {/* 녹음 버튼 */}
+        <div style={{ position: "fixed", bottom: 20, right: 20, zIndex: 1100 }}>
           {!recording ? (
             <button
               onClick={startRecording}

--- a/my-project/src/pages/InterviewPage.tsx
+++ b/my-project/src/pages/InterviewPage.tsx
@@ -21,8 +21,12 @@ const InterviewPage = () => {
   const { interviewId, setInterviewId, recording } = useInterviewStore();
 
   const { startRecording, stopRecording } = useAudioRecorder();
-  const { startVideoRecording, stopVideoRecording, videoChunksRef } =
-    useVideoRecorder();
+  const {
+    videoRecording,
+    startVideoRecording,
+    stopVideoRecording,
+    videoChunksRef,
+  } = useVideoRecorder();
 
   // 면접 ID 설정
   useEffect(() => {
@@ -35,8 +39,11 @@ const InterviewPage = () => {
 
   // 영상 녹화 시작
   useEffect(() => {
-    startVideoRecording();
-  }, [startVideoRecording]);
+    if (!videoRecording) {
+      startVideoRecording();
+      console.log("🎥 startVideoRecording 실행됨");
+    }
+  }, [videoRecording, startVideoRecording]);
 
   return (
     <div className="flex flex-col h-screen">

--- a/my-project/src/pages/ReportPage.tsx
+++ b/my-project/src/pages/ReportPage.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from "react";
-import axios from "axios";
+
 import Header_login from "../components/headers/Header_login";
 import ComprehensiveReport from "../components/reports/ComprehensiveReport";
 import QuestionReport from "../components/reports/QuestionReport";
@@ -7,6 +7,7 @@ import BehaviorReport from "../components/reports/BehaviorReport";
 import "../index.css";
 import { FaFilePdf } from "react-icons/fa";
 import { useLocation } from "react-router-dom";
+import axiosInstance from "../api/axiosInstance";
 
 const ReportPage = () => {
   const location = useLocation();
@@ -28,17 +29,14 @@ const ReportPage = () => {
       try {
         // 첫 번째 API 실행 (행동 데이터 분석)
         console.log("Executing first API: Behavior analysis");
-        await axios.post(
-          `http://localhost:8000/api/apps/behavior/${interviewId}`,
-          {}
-        );
+        await axiosInstance.post(`/api/apps/behavior/${interviewId}`, {});
 
         // 첫 번째 API가 성공하면 두 번째 API 실행 (결과 데이터 가져오기)
         console.log(
           "First API succeeded, executing second API: Fetching results"
         );
-        const response = await axios.post(
-          `http://localhost:8000/api/apps/result/${interviewId}`,
+        const response = await axiosInstance.post(
+          `/api/apps/result/${interviewId}`,
           {
             user_id: 1,
             question_count: 3,

--- a/my-project/src/pages/StartPage.tsx
+++ b/my-project/src/pages/StartPage.tsx
@@ -1,7 +1,4 @@
-import book from "../assets/book.svg";
-import flyingBusinessman from "../assets/flyingBusinessman.svg";
-import flyingBusinesswoman from "../assets/flyingBusinesswoman.svg";
-import Robot from "../assets/Robot.svg";
+import { IMAGES } from "../utils/constants";
 import Header_login from "../components/headers/Header_login";
 import "../index.css";
 interface StartPageProps {
@@ -45,26 +42,26 @@ const StartPage = ({ openUploadingModal }: StartPageProps) => {
 
           {/* 책 */}
           <img
-            src={book}
+            src={IMAGES.book}
             alt="Book"
             className="fixed w-32 bottom-40 right-80 animate-float"
           />
           {/* 남자 */}
           <img
-            src={flyingBusinessman}
+            src={IMAGES.flyingBusinessman}
             alt="Flying Businessman"
             className="fixed w-1/3 top-60 right-96 animate-float-slow"
           />
           {/* 여자 */}
           <img
-            src={flyingBusinesswoman}
+            src={IMAGES.flyingBusinesswoman}
             alt="Flying Businesswoman"
             className="fixed w-80 bottom-40 right-0 animate-float-fast"
             style={{ right: 0 }}
           />
           {/* 로봇 */}
           <img
-            src={Robot}
+            src={IMAGES.Robot}
             alt="Robot"
             className="fixed w-32 top-50 right-40 animate-float-fast"
           />

--- a/my-project/src/pages/StartPage.tsx
+++ b/my-project/src/pages/StartPage.tsx
@@ -1,72 +1,20 @@
-import { IMAGES } from "../utils/constants";
 import Header_login from "../components/headers/Header_login";
-import "../index.css";
+import StartPageContent from "../components/StartPageContent";
+import useStartPage from "../hooks/useStartPage";
+
 interface StartPageProps {
   openUploadingModal: () => void; // 이력서 업로드 모달 열기 핸들러
 }
+
 const StartPage = ({ openUploadingModal }: StartPageProps) => {
+  const { handleStartClick } = useStartPage(openUploadingModal);
+
   return (
-    <div className="flex flex-col h-screen ">
+    <div className="flex flex-col h-screen">
       {/* 헤더 */}
       <Header_login />
       {/* 메인 컨텐츠 */}
-      <main className="flex flex-1 items-center justify-center px-16 ">
-        {/* 좌측 텍스트 & 버튼 */}
-        <div className="w-1/2 space-y-4">
-          <p className="text-3xl font-museo text-gray-700 font-semibold">
-            내가 주인공인 순간, 시작은 여기에서!
-          </p>
-          <h2 className="text-5xl font-museo font-bold tracking-normal leading-[1.5]">
-            맞춤형 피드백과 <br /> 전문적인 분석으로 <br /> 나만의 이야기를
-            완성하는
-          </h2>
-          <h2 className="text-5xl font-museo font-bold bg-gradient-to-b from-[#312594] via-[#4F41CE] to-[#8072F8] text-transparent bg-clip-text tracking-wide">
-            AI 모의면접 서비스
-          </h2>
-
-          <button
-            className="px-8 py-3 font-museo text-lg font-semibold text-white bg-indigo-600 rounded-md hover:bg-indigo-700 tracking-widest relative top-4"
-            onClick={() => {
-              console.log("모달 열기 버튼 클릭됨");
-              openUploadingModal();
-            }}
-          >
-            면접 시작하기
-          </button>
-        </div>
-
-        {/* 우측 이미지 */}
-        <div className="relative w-1/2 h-[500px]">
-          {/* 보라색 모형 */}
-          <div className="fixed w-[810px] h-[380px] bg-gradient-to-b from-[#6859ED] to-[#FF94D6] rounded-l-full top-60 right-0 opacity-80 z-0"></div>
-
-          {/* 책 */}
-          <img
-            src={IMAGES.book}
-            alt="Book"
-            className="fixed w-32 bottom-40 right-80 animate-float"
-          />
-          {/* 남자 */}
-          <img
-            src={IMAGES.flyingBusinessman}
-            alt="Flying Businessman"
-            className="fixed w-1/3 top-60 right-96 animate-float-slow"
-          />
-          {/* 여자 */}
-          <img
-            src={IMAGES.flyingBusinesswoman}
-            alt="Flying Businesswoman"
-            className="fixed w-80 bottom-40 right-0 animate-float-fast"
-            style={{ right: 0 }}
-          />
-          {/* 로봇 */}
-          <img
-            src={IMAGES.Robot}
-            alt="Robot"
-            className="fixed w-32 top-50 right-40 animate-float-fast"
-          />
-        </div>
-      </main>
+      <StartPageContent handleStartClick={handleStartClick} />
     </div>
   );
 };

--- a/my-project/src/store/useInterviewStore.ts
+++ b/my-project/src/store/useInterviewStore.ts
@@ -1,0 +1,27 @@
+import { create } from "zustand";
+
+interface InterviewState {
+  interviewId: number | null;
+  socket: WebSocket | null;
+  recording: boolean;
+  videoRecording: boolean;
+
+  setInterviewId: (id: number) => void;
+  setSocket: (socket: WebSocket | null) => void;
+  setRecording: (recording: boolean) => void;
+  setVideoRecording: (recording: boolean) => void;
+}
+
+const useInterviewStore = create<InterviewState>((set) => ({
+  interviewId: null,
+  socket: null,
+  recording: false,
+  videoRecording: false,
+
+  setInterviewId: (id) => set({ interviewId: id }),
+  setSocket: (socket) => set({ socket }),
+  setRecording: (recording) => set({ recording }),
+  setVideoRecording: (recording) => set({ videoRecording: recording }),
+}));
+
+export default useInterviewStore;

--- a/my-project/src/utils/constants.ts
+++ b/my-project/src/utils/constants.ts
@@ -1,0 +1,11 @@
+import book from "../assets/book.svg";
+import flyingBusinessman from "../assets/flyingBusinessman.svg";
+import flyingBusinesswoman from "../assets/flyingBusinesswoman.svg";
+import Robot from "../assets/Robot.svg";
+
+export const IMAGES = {
+  book,
+  flyingBusinessman,
+  flyingBusinesswoman,
+  Robot,
+};

--- a/my-project/src/utils/constants.ts
+++ b/my-project/src/utils/constants.ts
@@ -2,10 +2,12 @@ import book from "../assets/book.svg";
 import flyingBusinessman from "../assets/flyingBusinessman.svg";
 import flyingBusinesswoman from "../assets/flyingBusinesswoman.svg";
 import robot from "../assets/Robot.svg";
+import Man from "../assets/Man.svg";
 
 export const IMAGES = {
   book,
   flyingBusinessman,
   flyingBusinesswoman,
   robot,
+  Man,
 };

--- a/my-project/src/utils/constants.ts
+++ b/my-project/src/utils/constants.ts
@@ -1,11 +1,11 @@
 import book from "../assets/book.svg";
 import flyingBusinessman from "../assets/flyingBusinessman.svg";
 import flyingBusinesswoman from "../assets/flyingBusinesswoman.svg";
-import Robot from "../assets/Robot.svg";
+import robot from "../assets/Robot.svg";
 
 export const IMAGES = {
   book,
   flyingBusinessman,
   flyingBusinesswoman,
-  Robot,
+  robot,
 };

--- a/my-project/src/utils/constants.ts
+++ b/my-project/src/utils/constants.ts
@@ -3,6 +3,12 @@ import flyingBusinessman from "../assets/flyingBusinessman.svg";
 import flyingBusinesswoman from "../assets/flyingBusinesswoman.svg";
 import robot from "../assets/Robot.svg";
 import Man from "../assets/Man.svg";
+import Record from "../assets/Record.svg";
+import face1 from "../assets/face1.png";
+import face2 from "../assets/face2.png";
+import face3 from "../assets/face3.png";
+import face4 from "../assets/face4.png";
+import face5 from "../assets/face5.png";
 
 export const IMAGES = {
   book,
@@ -10,4 +16,10 @@ export const IMAGES = {
   flyingBusinesswoman,
   robot,
   Man,
+  Record,
+  face1,
+  face2,
+  face3,
+  face4,
+  face5,
 };

--- a/node_modules/.yarn-integrity
+++ b/node_modules/.yarn-integrity
@@ -1,10 +1,16 @@
 {
   "systemParams": "darwin-arm64-127",
-  "modulesFolders": [],
+  "modulesFolders": [
+    "node_modules"
+  ],
   "flags": [],
   "linkedModules": [],
-  "topLevelPatterns": [],
-  "lockfileEntries": {},
+  "topLevelPatterns": [
+    "zustand@^5.0.3"
+  ],
+  "lockfileEntries": {
+    "zustand@^5.0.3": "https://registry.yarnpkg.com/zustand/-/zustand-5.0.3.tgz#b323435b73d06b2512e93c77239634374b0e407f"
+  },
   "files": [],
   "artifacts": {}
 }

--- a/node_modules/zustand/LICENSE
+++ b/node_modules/zustand/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2019 Paul Henschel
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/node_modules/zustand/esm/index.d.mts
+++ b/node_modules/zustand/esm/index.d.mts
@@ -1,0 +1,2 @@
+export * from 'zustand/vanilla';
+export * from 'zustand/react';

--- a/node_modules/zustand/esm/index.mjs
+++ b/node_modules/zustand/esm/index.mjs
@@ -1,0 +1,2 @@
+export * from 'zustand/vanilla';
+export * from 'zustand/react';

--- a/node_modules/zustand/esm/middleware.d.mts
+++ b/node_modules/zustand/esm/middleware.d.mts
@@ -1,0 +1,5 @@
+export * from './middleware/redux.mjs';
+export * from './middleware/devtools.mjs';
+export * from './middleware/subscribeWithSelector.mjs';
+export * from './middleware/combine.mjs';
+export * from './middleware/persist.mjs';

--- a/node_modules/zustand/esm/middleware.mjs
+++ b/node_modules/zustand/esm/middleware.mjs
@@ -1,0 +1,433 @@
+const reduxImpl = (reducer, initial) => (set, _get, api) => {
+  api.dispatch = (action) => {
+    set((state) => reducer(state, action), false, action);
+    return action;
+  };
+  api.dispatchFromDevtools = true;
+  return { dispatch: (...a) => api.dispatch(...a), ...initial };
+};
+const redux = reduxImpl;
+
+const trackedConnections = /* @__PURE__ */ new Map();
+const getTrackedConnectionState = (name) => {
+  const api = trackedConnections.get(name);
+  if (!api) return {};
+  return Object.fromEntries(
+    Object.entries(api.stores).map(([key, api2]) => [key, api2.getState()])
+  );
+};
+const extractConnectionInformation = (store, extensionConnector, options) => {
+  if (store === undefined) {
+    return {
+      type: "untracked",
+      connection: extensionConnector.connect(options)
+    };
+  }
+  const existingConnection = trackedConnections.get(options.name);
+  if (existingConnection) {
+    return { type: "tracked", store, ...existingConnection };
+  }
+  const newConnection = {
+    connection: extensionConnector.connect(options),
+    stores: {}
+  };
+  trackedConnections.set(options.name, newConnection);
+  return { type: "tracked", store, ...newConnection };
+};
+const devtoolsImpl = (fn, devtoolsOptions = {}) => (set, get, api) => {
+  const { enabled, anonymousActionType, store, ...options } = devtoolsOptions;
+  let extensionConnector;
+  try {
+    extensionConnector = (enabled != null ? enabled : (import.meta.env ? import.meta.env.MODE : void 0) !== "production") && window.__REDUX_DEVTOOLS_EXTENSION__;
+  } catch (e) {
+  }
+  if (!extensionConnector) {
+    return fn(set, get, api);
+  }
+  const { connection, ...connectionInformation } = extractConnectionInformation(store, extensionConnector, options);
+  let isRecording = true;
+  api.setState = (state, replace, nameOrAction) => {
+    const r = set(state, replace);
+    if (!isRecording) return r;
+    const action = nameOrAction === undefined ? { type: anonymousActionType || "anonymous" } : typeof nameOrAction === "string" ? { type: nameOrAction } : nameOrAction;
+    if (store === undefined) {
+      connection == null ? undefined : connection.send(action, get());
+      return r;
+    }
+    connection == null ? undefined : connection.send(
+      {
+        ...action,
+        type: `${store}/${action.type}`
+      },
+      {
+        ...getTrackedConnectionState(options.name),
+        [store]: api.getState()
+      }
+    );
+    return r;
+  };
+  const setStateFromDevtools = (...a) => {
+    const originalIsRecording = isRecording;
+    isRecording = false;
+    set(...a);
+    isRecording = originalIsRecording;
+  };
+  const initialState = fn(api.setState, get, api);
+  if (connectionInformation.type === "untracked") {
+    connection == null ? undefined : connection.init(initialState);
+  } else {
+    connectionInformation.stores[connectionInformation.store] = api;
+    connection == null ? undefined : connection.init(
+      Object.fromEntries(
+        Object.entries(connectionInformation.stores).map(([key, store2]) => [
+          key,
+          key === connectionInformation.store ? initialState : store2.getState()
+        ])
+      )
+    );
+  }
+  if (api.dispatchFromDevtools && typeof api.dispatch === "function") {
+    let didWarnAboutReservedActionType = false;
+    const originalDispatch = api.dispatch;
+    api.dispatch = (...a) => {
+      if ((import.meta.env ? import.meta.env.MODE : undefined) !== "production" && a[0].type === "__setState" && !didWarnAboutReservedActionType) {
+        console.warn(
+          '[zustand devtools middleware] "__setState" action type is reserved to set state from the devtools. Avoid using it.'
+        );
+        didWarnAboutReservedActionType = true;
+      }
+      originalDispatch(...a);
+    };
+  }
+  connection.subscribe((message) => {
+    var _a;
+    switch (message.type) {
+      case "ACTION":
+        if (typeof message.payload !== "string") {
+          console.error(
+            "[zustand devtools middleware] Unsupported action format"
+          );
+          return;
+        }
+        return parseJsonThen(
+          message.payload,
+          (action) => {
+            if (action.type === "__setState") {
+              if (store === undefined) {
+                setStateFromDevtools(action.state);
+                return;
+              }
+              if (Object.keys(action.state).length !== 1) {
+                console.error(
+                  `
+                    [zustand devtools middleware] Unsupported __setState action format.
+                    When using 'store' option in devtools(), the 'state' should have only one key, which is a value of 'store' that was passed in devtools(),
+                    and value of this only key should be a state object. Example: { "type": "__setState", "state": { "abc123Store": { "foo": "bar" } } }
+                    `
+                );
+              }
+              const stateFromDevtools = action.state[store];
+              if (stateFromDevtools === undefined || stateFromDevtools === null) {
+                return;
+              }
+              if (JSON.stringify(api.getState()) !== JSON.stringify(stateFromDevtools)) {
+                setStateFromDevtools(stateFromDevtools);
+              }
+              return;
+            }
+            if (!api.dispatchFromDevtools) return;
+            if (typeof api.dispatch !== "function") return;
+            api.dispatch(action);
+          }
+        );
+      case "DISPATCH":
+        switch (message.payload.type) {
+          case "RESET":
+            setStateFromDevtools(initialState);
+            if (store === undefined) {
+              return connection == null ? undefined : connection.init(api.getState());
+            }
+            return connection == null ? undefined : connection.init(getTrackedConnectionState(options.name));
+          case "COMMIT":
+            if (store === undefined) {
+              connection == null ? undefined : connection.init(api.getState());
+              return;
+            }
+            return connection == null ? undefined : connection.init(getTrackedConnectionState(options.name));
+          case "ROLLBACK":
+            return parseJsonThen(message.state, (state) => {
+              if (store === undefined) {
+                setStateFromDevtools(state);
+                connection == null ? undefined : connection.init(api.getState());
+                return;
+              }
+              setStateFromDevtools(state[store]);
+              connection == null ? undefined : connection.init(getTrackedConnectionState(options.name));
+            });
+          case "JUMP_TO_STATE":
+          case "JUMP_TO_ACTION":
+            return parseJsonThen(message.state, (state) => {
+              if (store === undefined) {
+                setStateFromDevtools(state);
+                return;
+              }
+              if (JSON.stringify(api.getState()) !== JSON.stringify(state[store])) {
+                setStateFromDevtools(state[store]);
+              }
+            });
+          case "IMPORT_STATE": {
+            const { nextLiftedState } = message.payload;
+            const lastComputedState = (_a = nextLiftedState.computedStates.slice(-1)[0]) == null ? undefined : _a.state;
+            if (!lastComputedState) return;
+            if (store === undefined) {
+              setStateFromDevtools(lastComputedState);
+            } else {
+              setStateFromDevtools(lastComputedState[store]);
+            }
+            connection == null ? undefined : connection.send(
+              null,
+              // FIXME no-any
+              nextLiftedState
+            );
+            return;
+          }
+          case "PAUSE_RECORDING":
+            return isRecording = !isRecording;
+        }
+        return;
+    }
+  });
+  return initialState;
+};
+const devtools = devtoolsImpl;
+const parseJsonThen = (stringified, f) => {
+  let parsed;
+  try {
+    parsed = JSON.parse(stringified);
+  } catch (e) {
+    console.error(
+      "[zustand devtools middleware] Could not parse the received json",
+      e
+    );
+  }
+  if (parsed !== undefined) f(parsed);
+};
+
+const subscribeWithSelectorImpl = (fn) => (set, get, api) => {
+  const origSubscribe = api.subscribe;
+  api.subscribe = (selector, optListener, options) => {
+    let listener = selector;
+    if (optListener) {
+      const equalityFn = (options == null ? undefined : options.equalityFn) || Object.is;
+      let currentSlice = selector(api.getState());
+      listener = (state) => {
+        const nextSlice = selector(state);
+        if (!equalityFn(currentSlice, nextSlice)) {
+          const previousSlice = currentSlice;
+          optListener(currentSlice = nextSlice, previousSlice);
+        }
+      };
+      if (options == null ? undefined : options.fireImmediately) {
+        optListener(currentSlice, currentSlice);
+      }
+    }
+    return origSubscribe(listener);
+  };
+  const initialState = fn(set, get, api);
+  return initialState;
+};
+const subscribeWithSelector = subscribeWithSelectorImpl;
+
+const combine = (initialState, create) => (...a) => Object.assign({}, initialState, create(...a));
+
+function createJSONStorage(getStorage, options) {
+  let storage;
+  try {
+    storage = getStorage();
+  } catch (e) {
+    return;
+  }
+  const persistStorage = {
+    getItem: (name) => {
+      var _a;
+      const parse = (str2) => {
+        if (str2 === null) {
+          return null;
+        }
+        return JSON.parse(str2, options == null ? undefined : options.reviver);
+      };
+      const str = (_a = storage.getItem(name)) != null ? _a : null;
+      if (str instanceof Promise) {
+        return str.then(parse);
+      }
+      return parse(str);
+    },
+    setItem: (name, newValue) => storage.setItem(
+      name,
+      JSON.stringify(newValue, options == null ? undefined : options.replacer)
+    ),
+    removeItem: (name) => storage.removeItem(name)
+  };
+  return persistStorage;
+}
+const toThenable = (fn) => (input) => {
+  try {
+    const result = fn(input);
+    if (result instanceof Promise) {
+      return result;
+    }
+    return {
+      then(onFulfilled) {
+        return toThenable(onFulfilled)(result);
+      },
+      catch(_onRejected) {
+        return this;
+      }
+    };
+  } catch (e) {
+    return {
+      then(_onFulfilled) {
+        return this;
+      },
+      catch(onRejected) {
+        return toThenable(onRejected)(e);
+      }
+    };
+  }
+};
+const persistImpl = (config, baseOptions) => (set, get, api) => {
+  let options = {
+    storage: createJSONStorage(() => localStorage),
+    partialize: (state) => state,
+    version: 0,
+    merge: (persistedState, currentState) => ({
+      ...currentState,
+      ...persistedState
+    }),
+    ...baseOptions
+  };
+  let hasHydrated = false;
+  const hydrationListeners = /* @__PURE__ */ new Set();
+  const finishHydrationListeners = /* @__PURE__ */ new Set();
+  let storage = options.storage;
+  if (!storage) {
+    return config(
+      (...args) => {
+        console.warn(
+          `[zustand persist middleware] Unable to update item '${options.name}', the given storage is currently unavailable.`
+        );
+        set(...args);
+      },
+      get,
+      api
+    );
+  }
+  const setItem = () => {
+    const state = options.partialize({ ...get() });
+    return storage.setItem(options.name, {
+      state,
+      version: options.version
+    });
+  };
+  const savedSetState = api.setState;
+  api.setState = (state, replace) => {
+    savedSetState(state, replace);
+    void setItem();
+  };
+  const configResult = config(
+    (...args) => {
+      set(...args);
+      void setItem();
+    },
+    get,
+    api
+  );
+  api.getInitialState = () => configResult;
+  let stateFromStorage;
+  const hydrate = () => {
+    var _a, _b;
+    if (!storage) return;
+    hasHydrated = false;
+    hydrationListeners.forEach((cb) => {
+      var _a2;
+      return cb((_a2 = get()) != null ? _a2 : configResult);
+    });
+    const postRehydrationCallback = ((_b = options.onRehydrateStorage) == null ? undefined : _b.call(options, (_a = get()) != null ? _a : configResult)) || undefined;
+    return toThenable(storage.getItem.bind(storage))(options.name).then((deserializedStorageValue) => {
+      if (deserializedStorageValue) {
+        if (typeof deserializedStorageValue.version === "number" && deserializedStorageValue.version !== options.version) {
+          if (options.migrate) {
+            const migration = options.migrate(
+              deserializedStorageValue.state,
+              deserializedStorageValue.version
+            );
+            if (migration instanceof Promise) {
+              return migration.then((result) => [true, result]);
+            }
+            return [true, migration];
+          }
+          console.error(
+            `State loaded from storage couldn't be migrated since no migrate function was provided`
+          );
+        } else {
+          return [false, deserializedStorageValue.state];
+        }
+      }
+      return [false, undefined];
+    }).then((migrationResult) => {
+      var _a2;
+      const [migrated, migratedState] = migrationResult;
+      stateFromStorage = options.merge(
+        migratedState,
+        (_a2 = get()) != null ? _a2 : configResult
+      );
+      set(stateFromStorage, true);
+      if (migrated) {
+        return setItem();
+      }
+    }).then(() => {
+      postRehydrationCallback == null ? undefined : postRehydrationCallback(stateFromStorage, undefined);
+      stateFromStorage = get();
+      hasHydrated = true;
+      finishHydrationListeners.forEach((cb) => cb(stateFromStorage));
+    }).catch((e) => {
+      postRehydrationCallback == null ? undefined : postRehydrationCallback(undefined, e);
+    });
+  };
+  api.persist = {
+    setOptions: (newOptions) => {
+      options = {
+        ...options,
+        ...newOptions
+      };
+      if (newOptions.storage) {
+        storage = newOptions.storage;
+      }
+    },
+    clearStorage: () => {
+      storage == null ? undefined : storage.removeItem(options.name);
+    },
+    getOptions: () => options,
+    rehydrate: () => hydrate(),
+    hasHydrated: () => hasHydrated,
+    onHydrate: (cb) => {
+      hydrationListeners.add(cb);
+      return () => {
+        hydrationListeners.delete(cb);
+      };
+    },
+    onFinishHydration: (cb) => {
+      finishHydrationListeners.add(cb);
+      return () => {
+        finishHydrationListeners.delete(cb);
+      };
+    }
+  };
+  if (!options.skipHydration) {
+    hydrate();
+  }
+  return stateFromStorage || configResult;
+};
+const persist = persistImpl;
+
+export { combine, createJSONStorage, devtools, persist, redux, subscribeWithSelector };

--- a/node_modules/zustand/esm/middleware/combine.d.mts
+++ b/node_modules/zustand/esm/middleware/combine.d.mts
@@ -1,0 +1,5 @@
+import type { StateCreator, StoreMutatorIdentifier } from 'zustand/vanilla';
+type Write<T, U> = Omit<T, keyof U> & U;
+type Combine = <T extends object, U extends object, Mps extends [StoreMutatorIdentifier, unknown][] = [], Mcs extends [StoreMutatorIdentifier, unknown][] = []>(initialState: T, additionalStateCreator: StateCreator<T, Mps, Mcs, U>) => StateCreator<Write<T, U>, Mps, Mcs>;
+export declare const combine: Combine;
+export {};

--- a/node_modules/zustand/esm/middleware/devtools.d.mts
+++ b/node_modules/zustand/esm/middleware/devtools.d.mts
@@ -1,0 +1,55 @@
+import type { StateCreator, StoreApi, StoreMutatorIdentifier } from 'zustand/vanilla';
+type Config = Parameters<(Window extends {
+    __REDUX_DEVTOOLS_EXTENSION__?: infer T;
+} ? T : {
+    connect: (param: any) => any;
+})['connect']>[0];
+declare module '../vanilla.mjs' {
+    interface StoreMutators<S, A> {
+        'zustand/devtools': WithDevtools<S>;
+    }
+}
+type Cast<T, U> = T extends U ? T : U;
+type Write<T, U> = Omit<T, keyof U> & U;
+type TakeTwo<T> = T extends {
+    length: 0;
+} ? [undefined, undefined] : T extends {
+    length: 1;
+} ? [...a0: Cast<T, unknown[]>, a1: undefined] : T extends {
+    length: 0 | 1;
+} ? [...a0: Cast<T, unknown[]>, a1: undefined] : T extends {
+    length: 2;
+} ? T : T extends {
+    length: 1 | 2;
+} ? T : T extends {
+    length: 0 | 1 | 2;
+} ? T : T extends [infer A0, infer A1, ...unknown[]] ? [A0, A1] : T extends [infer A0, (infer A1)?, ...unknown[]] ? [A0, A1?] : T extends [(infer A0)?, (infer A1)?, ...unknown[]] ? [A0?, A1?] : never;
+type WithDevtools<S> = Write<S, StoreDevtools<S>>;
+type Action = string | {
+    type: string;
+    [x: string | number | symbol]: unknown;
+};
+type StoreDevtools<S> = S extends {
+    setState: {
+        (...a: infer Sa1): infer Sr1;
+        (...a: infer Sa2): infer Sr2;
+    };
+} ? {
+    setState(...a: [...a: TakeTwo<Sa1>, action?: Action]): Sr1;
+    setState(...a: [...a: TakeTwo<Sa2>, action?: Action]): Sr2;
+} : never;
+export interface DevtoolsOptions extends Config {
+    name?: string;
+    enabled?: boolean;
+    anonymousActionType?: string;
+    store?: string;
+}
+type Devtools = <T, Mps extends [StoreMutatorIdentifier, unknown][] = [], Mcs extends [StoreMutatorIdentifier, unknown][] = [], U = T>(initializer: StateCreator<T, [...Mps, ['zustand/devtools', never]], Mcs, U>, devtoolsOptions?: DevtoolsOptions) => StateCreator<T, Mps, [['zustand/devtools', never], ...Mcs]>;
+declare module '../vanilla.mjs' {
+    interface StoreMutators<S, A> {
+        'zustand/devtools': WithDevtools<S>;
+    }
+}
+export type NamedSet<T> = WithDevtools<StoreApi<T>>['setState'];
+export declare const devtools: Devtools;
+export {};

--- a/node_modules/zustand/esm/middleware/immer.d.mts
+++ b/node_modules/zustand/esm/middleware/immer.d.mts
@@ -1,0 +1,29 @@
+import type { Draft } from 'immer';
+import type { StateCreator, StoreMutatorIdentifier } from 'zustand/vanilla';
+type Immer = <T, Mps extends [StoreMutatorIdentifier, unknown][] = [], Mcs extends [StoreMutatorIdentifier, unknown][] = []>(initializer: StateCreator<T, [...Mps, ['zustand/immer', never]], Mcs>) => StateCreator<T, Mps, [['zustand/immer', never], ...Mcs]>;
+declare module '../vanilla.mjs' {
+    interface StoreMutators<S, A> {
+        ['zustand/immer']: WithImmer<S>;
+    }
+}
+type Write<T, U> = Omit<T, keyof U> & U;
+type SkipTwo<T> = T extends {
+    length: 0;
+} ? [] : T extends {
+    length: 1;
+} ? [] : T extends {
+    length: 0 | 1;
+} ? [] : T extends [unknown, unknown, ...infer A] ? A : T extends [unknown, unknown?, ...infer A] ? A : T extends [unknown?, unknown?, ...infer A] ? A : never;
+type SetStateType<T extends unknown[]> = Exclude<T[0], (...args: any[]) => any>;
+type WithImmer<S> = Write<S, StoreImmer<S>>;
+type StoreImmer<S> = S extends {
+    setState: infer SetState;
+} ? SetState extends {
+    (...a: infer A1): infer Sr1;
+    (...a: infer A2): infer Sr2;
+} ? {
+    setState(nextStateOrUpdater: SetStateType<A2> | Partial<SetStateType<A2>> | ((state: Draft<SetStateType<A2>>) => void), shouldReplace?: false, ...a: SkipTwo<A1>): Sr1;
+    setState(nextStateOrUpdater: SetStateType<A2> | ((state: Draft<SetStateType<A2>>) => void), shouldReplace: true, ...a: SkipTwo<A2>): Sr2;
+} : never : never;
+export declare const immer: Immer;
+export {};

--- a/node_modules/zustand/esm/middleware/immer.mjs
+++ b/node_modules/zustand/esm/middleware/immer.mjs
@@ -1,0 +1,12 @@
+import { produce } from 'immer';
+
+const immerImpl = (initializer) => (set, get, store) => {
+  store.setState = (updater, replace, ...a) => {
+    const nextState = typeof updater === "function" ? produce(updater) : updater;
+    return set(nextState, replace, ...a);
+  };
+  return initializer(store.setState, get, store);
+};
+const immer = immerImpl;
+
+export { immer };

--- a/node_modules/zustand/esm/middleware/persist.d.mts
+++ b/node_modules/zustand/esm/middleware/persist.d.mts
@@ -1,0 +1,93 @@
+import type { StateCreator, StoreMutatorIdentifier } from 'zustand/vanilla';
+export interface StateStorage {
+    getItem: (name: string) => string | null | Promise<string | null>;
+    setItem: (name: string, value: string) => unknown | Promise<unknown>;
+    removeItem: (name: string) => unknown | Promise<unknown>;
+}
+export type StorageValue<S> = {
+    state: S;
+    version?: number;
+};
+export interface PersistStorage<S> {
+    getItem: (name: string) => StorageValue<S> | null | Promise<StorageValue<S> | null>;
+    setItem: (name: string, value: StorageValue<S>) => unknown | Promise<unknown>;
+    removeItem: (name: string) => unknown | Promise<unknown>;
+}
+type JsonStorageOptions = {
+    reviver?: (key: string, value: unknown) => unknown;
+    replacer?: (key: string, value: unknown) => unknown;
+};
+export declare function createJSONStorage<S>(getStorage: () => StateStorage, options?: JsonStorageOptions): PersistStorage<S> | undefined;
+export interface PersistOptions<S, PersistedState = S> {
+    /** Name of the storage (must be unique) */
+    name: string;
+    /**
+     * Use a custom persist storage.
+     *
+     * Combining `createJSONStorage` helps creating a persist storage
+     * with JSON.parse and JSON.stringify.
+     *
+     * @default createJSONStorage(() => localStorage)
+     */
+    storage?: PersistStorage<PersistedState> | undefined;
+    /**
+     * Filter the persisted value.
+     *
+     * @params state The state's value
+     */
+    partialize?: (state: S) => PersistedState;
+    /**
+     * A function returning another (optional) function.
+     * The main function will be called before the state rehydration.
+     * The returned function will be called after the state rehydration or when an error occurred.
+     */
+    onRehydrateStorage?: (state: S) => ((state?: S, error?: unknown) => void) | void;
+    /**
+     * If the stored state's version mismatch the one specified here, the storage will not be used.
+     * This is useful when adding a breaking change to your store.
+     */
+    version?: number;
+    /**
+     * A function to perform persisted state migration.
+     * This function will be called when persisted state versions mismatch with the one specified here.
+     */
+    migrate?: (persistedState: unknown, version: number) => PersistedState | Promise<PersistedState>;
+    /**
+     * A function to perform custom hydration merges when combining the stored state with the current one.
+     * By default, this function does a shallow merge.
+     */
+    merge?: (persistedState: unknown, currentState: S) => S;
+    /**
+     * An optional boolean that will prevent the persist middleware from triggering hydration on initialization,
+     * This allows you to call `rehydrate()` at a specific point in your apps rendering life-cycle.
+     *
+     * This is useful in SSR application.
+     *
+     * @default false
+     */
+    skipHydration?: boolean;
+}
+type PersistListener<S> = (state: S) => void;
+type StorePersist<S, Ps> = {
+    persist: {
+        setOptions: (options: Partial<PersistOptions<S, Ps>>) => void;
+        clearStorage: () => void;
+        rehydrate: () => Promise<void> | void;
+        hasHydrated: () => boolean;
+        onHydrate: (fn: PersistListener<S>) => () => void;
+        onFinishHydration: (fn: PersistListener<S>) => () => void;
+        getOptions: () => Partial<PersistOptions<S, Ps>>;
+    };
+};
+type Persist = <T, Mps extends [StoreMutatorIdentifier, unknown][] = [], Mcs extends [StoreMutatorIdentifier, unknown][] = [], U = T>(initializer: StateCreator<T, [...Mps, ['zustand/persist', unknown]], Mcs>, options: PersistOptions<T, U>) => StateCreator<T, Mps, [['zustand/persist', U], ...Mcs]>;
+declare module '../vanilla.mjs' {
+    interface StoreMutators<S, A> {
+        'zustand/persist': WithPersist<S, A>;
+    }
+}
+type Write<T, U> = Omit<T, keyof U> & U;
+type WithPersist<S, A> = S extends {
+    getState: () => infer T;
+} ? Write<S, StorePersist<T, A>> : never;
+export declare const persist: Persist;
+export {};

--- a/node_modules/zustand/esm/middleware/redux.d.mts
+++ b/node_modules/zustand/esm/middleware/redux.d.mts
@@ -1,0 +1,21 @@
+import type { StateCreator, StoreMutatorIdentifier } from 'zustand/vanilla';
+type Write<T, U> = Omit<T, keyof U> & U;
+type Action = {
+    type: string;
+};
+type StoreRedux<A> = {
+    dispatch: (a: A) => A;
+    dispatchFromDevtools: true;
+};
+type ReduxState<A> = {
+    dispatch: StoreRedux<A>['dispatch'];
+};
+type WithRedux<S, A> = Write<S, StoreRedux<A>>;
+type Redux = <T, A extends Action, Cms extends [StoreMutatorIdentifier, unknown][] = []>(reducer: (state: T, action: A) => T, initialState: T) => StateCreator<Write<T, ReduxState<A>>, Cms, [['zustand/redux', A]]>;
+declare module '../vanilla.mjs' {
+    interface StoreMutators<S, A> {
+        'zustand/redux': WithRedux<S, A>;
+    }
+}
+export declare const redux: Redux;
+export {};

--- a/node_modules/zustand/esm/middleware/subscribeWithSelector.d.mts
+++ b/node_modules/zustand/esm/middleware/subscribeWithSelector.d.mts
@@ -1,0 +1,25 @@
+import type { StateCreator, StoreMutatorIdentifier } from 'zustand/vanilla';
+type SubscribeWithSelector = <T, Mps extends [StoreMutatorIdentifier, unknown][] = [], Mcs extends [StoreMutatorIdentifier, unknown][] = []>(initializer: StateCreator<T, [
+    ...Mps,
+    ['zustand/subscribeWithSelector', never]
+], Mcs>) => StateCreator<T, Mps, [['zustand/subscribeWithSelector', never], ...Mcs]>;
+type Write<T, U> = Omit<T, keyof U> & U;
+type WithSelectorSubscribe<S> = S extends {
+    getState: () => infer T;
+} ? Write<S, StoreSubscribeWithSelector<T>> : never;
+declare module '../vanilla.mjs' {
+    interface StoreMutators<S, A> {
+        ['zustand/subscribeWithSelector']: WithSelectorSubscribe<S>;
+    }
+}
+type StoreSubscribeWithSelector<T> = {
+    subscribe: {
+        (listener: (selectedState: T, previousSelectedState: T) => void): () => void;
+        <U>(selector: (state: T) => U, listener: (selectedState: U, previousSelectedState: U) => void, options?: {
+            equalityFn?: (a: U, b: U) => boolean;
+            fireImmediately?: boolean;
+        }): () => void;
+    };
+};
+export declare const subscribeWithSelector: SubscribeWithSelector;
+export {};

--- a/node_modules/zustand/esm/react.d.mts
+++ b/node_modules/zustand/esm/react.d.mts
@@ -1,0 +1,14 @@
+import type { ExtractState, Mutate, StateCreator, StoreApi, StoreMutatorIdentifier } from 'zustand/vanilla';
+type ReadonlyStoreApi<T> = Pick<StoreApi<T>, 'getState' | 'getInitialState' | 'subscribe'>;
+export declare function useStore<S extends ReadonlyStoreApi<unknown>>(api: S): ExtractState<S>;
+export declare function useStore<S extends ReadonlyStoreApi<unknown>, U>(api: S, selector: (state: ExtractState<S>) => U): U;
+export type UseBoundStore<S extends ReadonlyStoreApi<unknown>> = {
+    (): ExtractState<S>;
+    <U>(selector: (state: ExtractState<S>) => U): U;
+} & S;
+type Create = {
+    <T, Mos extends [StoreMutatorIdentifier, unknown][] = []>(initializer: StateCreator<T, [], Mos>): UseBoundStore<Mutate<StoreApi<T>, Mos>>;
+    <T>(): <Mos extends [StoreMutatorIdentifier, unknown][] = []>(initializer: StateCreator<T, [], Mos>) => UseBoundStore<Mutate<StoreApi<T>, Mos>>;
+};
+export declare const create: Create;
+export {};

--- a/node_modules/zustand/esm/react.mjs
+++ b/node_modules/zustand/esm/react.mjs
@@ -1,0 +1,22 @@
+import React from 'react';
+import { createStore } from 'zustand/vanilla';
+
+const identity = (arg) => arg;
+function useStore(api, selector = identity) {
+  const slice = React.useSyncExternalStore(
+    api.subscribe,
+    () => selector(api.getState()),
+    () => selector(api.getInitialState())
+  );
+  React.useDebugValue(slice);
+  return slice;
+}
+const createImpl = (createState) => {
+  const api = createStore(createState);
+  const useBoundStore = (selector) => useStore(api, selector);
+  Object.assign(useBoundStore, api);
+  return useBoundStore;
+};
+const create = (createState) => createState ? createImpl(createState) : createImpl;
+
+export { create, useStore };

--- a/node_modules/zustand/esm/react/shallow.d.mts
+++ b/node_modules/zustand/esm/react/shallow.d.mts
@@ -1,0 +1,1 @@
+export declare function useShallow<S, U>(selector: (state: S) => U): (state: S) => U;

--- a/node_modules/zustand/esm/react/shallow.mjs
+++ b/node_modules/zustand/esm/react/shallow.mjs
@@ -1,0 +1,12 @@
+import React from 'react';
+import { shallow } from 'zustand/vanilla/shallow';
+
+function useShallow(selector) {
+  const prev = React.useRef(undefined);
+  return (state) => {
+    const next = selector(state);
+    return shallow(prev.current, next) ? prev.current : prev.current = next;
+  };
+}
+
+export { useShallow };

--- a/node_modules/zustand/esm/shallow.d.mts
+++ b/node_modules/zustand/esm/shallow.d.mts
@@ -1,0 +1,2 @@
+export { shallow } from 'zustand/vanilla/shallow';
+export { useShallow } from 'zustand/react/shallow';

--- a/node_modules/zustand/esm/shallow.mjs
+++ b/node_modules/zustand/esm/shallow.mjs
@@ -1,0 +1,2 @@
+export { shallow } from 'zustand/vanilla/shallow';
+export { useShallow } from 'zustand/react/shallow';

--- a/node_modules/zustand/esm/traditional.d.mts
+++ b/node_modules/zustand/esm/traditional.d.mts
@@ -1,0 +1,17 @@
+import type { Mutate, StateCreator, StoreApi, StoreMutatorIdentifier } from 'zustand/vanilla';
+type ExtractState<S> = S extends {
+    getState: () => infer T;
+} ? T : never;
+type ReadonlyStoreApi<T> = Pick<StoreApi<T>, 'getState' | 'getInitialState' | 'subscribe'>;
+export declare function useStoreWithEqualityFn<S extends ReadonlyStoreApi<unknown>>(api: S): ExtractState<S>;
+export declare function useStoreWithEqualityFn<S extends ReadonlyStoreApi<unknown>, U>(api: S, selector: (state: ExtractState<S>) => U, equalityFn?: (a: U, b: U) => boolean): U;
+export type UseBoundStoreWithEqualityFn<S extends ReadonlyStoreApi<unknown>> = {
+    (): ExtractState<S>;
+    <U>(selector: (state: ExtractState<S>) => U, equalityFn?: (a: U, b: U) => boolean): U;
+} & S;
+type CreateWithEqualityFn = {
+    <T, Mos extends [StoreMutatorIdentifier, unknown][] = []>(initializer: StateCreator<T, [], Mos>, defaultEqualityFn?: <U>(a: U, b: U) => boolean): UseBoundStoreWithEqualityFn<Mutate<StoreApi<T>, Mos>>;
+    <T>(): <Mos extends [StoreMutatorIdentifier, unknown][] = []>(initializer: StateCreator<T, [], Mos>, defaultEqualityFn?: <U>(a: U, b: U) => boolean) => UseBoundStoreWithEqualityFn<Mutate<StoreApi<T>, Mos>>;
+};
+export declare const createWithEqualityFn: CreateWithEqualityFn;
+export {};

--- a/node_modules/zustand/esm/traditional.mjs
+++ b/node_modules/zustand/esm/traditional.mjs
@@ -1,0 +1,26 @@
+import React from 'react';
+import useSyncExternalStoreExports from 'use-sync-external-store/shim/with-selector.js';
+import { createStore } from 'zustand/vanilla';
+
+const { useSyncExternalStoreWithSelector } = useSyncExternalStoreExports;
+const identity = (arg) => arg;
+function useStoreWithEqualityFn(api, selector = identity, equalityFn) {
+  const slice = useSyncExternalStoreWithSelector(
+    api.subscribe,
+    api.getState,
+    api.getInitialState,
+    selector,
+    equalityFn
+  );
+  React.useDebugValue(slice);
+  return slice;
+}
+const createWithEqualityFnImpl = (createState, defaultEqualityFn) => {
+  const api = createStore(createState);
+  const useBoundStoreWithEqualityFn = (selector, equalityFn = defaultEqualityFn) => useStoreWithEqualityFn(api, selector, equalityFn);
+  Object.assign(useBoundStoreWithEqualityFn, api);
+  return useBoundStoreWithEqualityFn;
+};
+const createWithEqualityFn = (createState, defaultEqualityFn) => createState ? createWithEqualityFnImpl(createState, defaultEqualityFn) : createWithEqualityFnImpl;
+
+export { createWithEqualityFn, useStoreWithEqualityFn };

--- a/node_modules/zustand/esm/vanilla.d.mts
+++ b/node_modules/zustand/esm/vanilla.d.mts
@@ -1,0 +1,31 @@
+type SetStateInternal<T> = {
+    _(partial: T | Partial<T> | {
+        _(state: T): T | Partial<T>;
+    }['_'], replace?: false): void;
+    _(state: T | {
+        _(state: T): T;
+    }['_'], replace: true): void;
+}['_'];
+export interface StoreApi<T> {
+    setState: SetStateInternal<T>;
+    getState: () => T;
+    getInitialState: () => T;
+    subscribe: (listener: (state: T, prevState: T) => void) => () => void;
+}
+export type ExtractState<S> = S extends {
+    getState: () => infer T;
+} ? T : never;
+type Get<T, K, F> = K extends keyof T ? T[K] : F;
+export type Mutate<S, Ms> = number extends Ms['length' & keyof Ms] ? S : Ms extends [] ? S : Ms extends [[infer Mi, infer Ma], ...infer Mrs] ? Mutate<StoreMutators<S, Ma>[Mi & StoreMutatorIdentifier], Mrs> : never;
+export type StateCreator<T, Mis extends [StoreMutatorIdentifier, unknown][] = [], Mos extends [StoreMutatorIdentifier, unknown][] = [], U = T> = ((setState: Get<Mutate<StoreApi<T>, Mis>, 'setState', never>, getState: Get<Mutate<StoreApi<T>, Mis>, 'getState', never>, store: Mutate<StoreApi<T>, Mis>) => U) & {
+    $$storeMutators?: Mos;
+};
+export interface StoreMutators<S, A> {
+}
+export type StoreMutatorIdentifier = keyof StoreMutators<unknown, unknown>;
+type CreateStore = {
+    <T, Mos extends [StoreMutatorIdentifier, unknown][] = []>(initializer: StateCreator<T, [], Mos>): Mutate<StoreApi<T>, Mos>;
+    <T>(): <Mos extends [StoreMutatorIdentifier, unknown][] = []>(initializer: StateCreator<T, [], Mos>) => Mutate<StoreApi<T>, Mos>;
+};
+export declare const createStore: CreateStore;
+export {};

--- a/node_modules/zustand/esm/vanilla.mjs
+++ b/node_modules/zustand/esm/vanilla.mjs
@@ -1,0 +1,24 @@
+const createStoreImpl = (createState) => {
+  let state;
+  const listeners = /* @__PURE__ */ new Set();
+  const setState = (partial, replace) => {
+    const nextState = typeof partial === "function" ? partial(state) : partial;
+    if (!Object.is(nextState, state)) {
+      const previousState = state;
+      state = (replace != null ? replace : typeof nextState !== "object" || nextState === null) ? nextState : Object.assign({}, state, nextState);
+      listeners.forEach((listener) => listener(state, previousState));
+    }
+  };
+  const getState = () => state;
+  const getInitialState = () => initialState;
+  const subscribe = (listener) => {
+    listeners.add(listener);
+    return () => listeners.delete(listener);
+  };
+  const api = { setState, getState, getInitialState, subscribe };
+  const initialState = state = createState(setState, getState, api);
+  return api;
+};
+const createStore = (createState) => createState ? createStoreImpl(createState) : createStoreImpl;
+
+export { createStore };

--- a/node_modules/zustand/esm/vanilla/shallow.d.mts
+++ b/node_modules/zustand/esm/vanilla/shallow.d.mts
@@ -1,0 +1,1 @@
+export declare function shallow<T>(valueA: T, valueB: T): boolean;

--- a/node_modules/zustand/esm/vanilla/shallow.mjs
+++ b/node_modules/zustand/esm/vanilla/shallow.mjs
@@ -1,0 +1,52 @@
+const isIterable = (obj) => Symbol.iterator in obj;
+const hasIterableEntries = (value) => (
+  // HACK: avoid checking entries type
+  "entries" in value
+);
+const compareEntries = (valueA, valueB) => {
+  const mapA = valueA instanceof Map ? valueA : new Map(valueA.entries());
+  const mapB = valueB instanceof Map ? valueB : new Map(valueB.entries());
+  if (mapA.size !== mapB.size) {
+    return false;
+  }
+  for (const [key, value] of mapA) {
+    if (!Object.is(value, mapB.get(key))) {
+      return false;
+    }
+  }
+  return true;
+};
+const compareIterables = (valueA, valueB) => {
+  const iteratorA = valueA[Symbol.iterator]();
+  const iteratorB = valueB[Symbol.iterator]();
+  let nextA = iteratorA.next();
+  let nextB = iteratorB.next();
+  while (!nextA.done && !nextB.done) {
+    if (!Object.is(nextA.value, nextB.value)) {
+      return false;
+    }
+    nextA = iteratorA.next();
+    nextB = iteratorB.next();
+  }
+  return !!nextA.done && !!nextB.done;
+};
+function shallow(valueA, valueB) {
+  if (Object.is(valueA, valueB)) {
+    return true;
+  }
+  if (typeof valueA !== "object" || valueA === null || typeof valueB !== "object" || valueB === null) {
+    return false;
+  }
+  if (!isIterable(valueA) || !isIterable(valueB)) {
+    return compareEntries(
+      { entries: () => Object.entries(valueA) },
+      { entries: () => Object.entries(valueB) }
+    );
+  }
+  if (hasIterableEntries(valueA) && hasIterableEntries(valueB)) {
+    return compareEntries(valueA, valueB);
+  }
+  return compareIterables(valueA, valueB);
+}
+
+export { shallow };

--- a/node_modules/zustand/index.d.ts
+++ b/node_modules/zustand/index.d.ts
@@ -1,0 +1,2 @@
+export * from 'zustand/vanilla';
+export * from 'zustand/react';

--- a/node_modules/zustand/index.js
+++ b/node_modules/zustand/index.js
@@ -1,0 +1,19 @@
+'use strict';
+
+var vanilla = require('zustand/vanilla');
+var react = require('zustand/react');
+
+
+
+Object.keys(vanilla).forEach(function (k) {
+	if (k !== 'default' && !Object.prototype.hasOwnProperty.call(exports, k)) Object.defineProperty(exports, k, {
+		enumerable: true,
+		get: function () { return vanilla[k]; }
+	});
+});
+Object.keys(react).forEach(function (k) {
+	if (k !== 'default' && !Object.prototype.hasOwnProperty.call(exports, k)) Object.defineProperty(exports, k, {
+		enumerable: true,
+		get: function () { return react[k]; }
+	});
+});

--- a/node_modules/zustand/middleware.d.ts
+++ b/node_modules/zustand/middleware.d.ts
@@ -1,0 +1,5 @@
+export * from './middleware/redux';
+export * from './middleware/devtools';
+export * from './middleware/subscribeWithSelector';
+export * from './middleware/combine';
+export * from './middleware/persist';

--- a/node_modules/zustand/middleware.js
+++ b/node_modules/zustand/middleware.js
@@ -1,0 +1,440 @@
+'use strict';
+
+const reduxImpl = (reducer, initial) => (set, _get, api) => {
+  api.dispatch = (action) => {
+    set((state) => reducer(state, action), false, action);
+    return action;
+  };
+  api.dispatchFromDevtools = true;
+  return { dispatch: (...a) => api.dispatch(...a), ...initial };
+};
+const redux = reduxImpl;
+
+const trackedConnections = /* @__PURE__ */ new Map();
+const getTrackedConnectionState = (name) => {
+  const api = trackedConnections.get(name);
+  if (!api) return {};
+  return Object.fromEntries(
+    Object.entries(api.stores).map(([key, api2]) => [key, api2.getState()])
+  );
+};
+const extractConnectionInformation = (store, extensionConnector, options) => {
+  if (store === undefined) {
+    return {
+      type: "untracked",
+      connection: extensionConnector.connect(options)
+    };
+  }
+  const existingConnection = trackedConnections.get(options.name);
+  if (existingConnection) {
+    return { type: "tracked", store, ...existingConnection };
+  }
+  const newConnection = {
+    connection: extensionConnector.connect(options),
+    stores: {}
+  };
+  trackedConnections.set(options.name, newConnection);
+  return { type: "tracked", store, ...newConnection };
+};
+const devtoolsImpl = (fn, devtoolsOptions = {}) => (set, get, api) => {
+  const { enabled, anonymousActionType, store, ...options } = devtoolsOptions;
+  let extensionConnector;
+  try {
+    extensionConnector = (enabled != null ? enabled : process.env.NODE_ENV !== "production") && window.__REDUX_DEVTOOLS_EXTENSION__;
+  } catch (e) {
+  }
+  if (!extensionConnector) {
+    return fn(set, get, api);
+  }
+  const { connection, ...connectionInformation } = extractConnectionInformation(store, extensionConnector, options);
+  let isRecording = true;
+  api.setState = (state, replace, nameOrAction) => {
+    const r = set(state, replace);
+    if (!isRecording) return r;
+    const action = nameOrAction === undefined ? { type: anonymousActionType || "anonymous" } : typeof nameOrAction === "string" ? { type: nameOrAction } : nameOrAction;
+    if (store === undefined) {
+      connection == null ? undefined : connection.send(action, get());
+      return r;
+    }
+    connection == null ? undefined : connection.send(
+      {
+        ...action,
+        type: `${store}/${action.type}`
+      },
+      {
+        ...getTrackedConnectionState(options.name),
+        [store]: api.getState()
+      }
+    );
+    return r;
+  };
+  const setStateFromDevtools = (...a) => {
+    const originalIsRecording = isRecording;
+    isRecording = false;
+    set(...a);
+    isRecording = originalIsRecording;
+  };
+  const initialState = fn(api.setState, get, api);
+  if (connectionInformation.type === "untracked") {
+    connection == null ? undefined : connection.init(initialState);
+  } else {
+    connectionInformation.stores[connectionInformation.store] = api;
+    connection == null ? undefined : connection.init(
+      Object.fromEntries(
+        Object.entries(connectionInformation.stores).map(([key, store2]) => [
+          key,
+          key === connectionInformation.store ? initialState : store2.getState()
+        ])
+      )
+    );
+  }
+  if (api.dispatchFromDevtools && typeof api.dispatch === "function") {
+    let didWarnAboutReservedActionType = false;
+    const originalDispatch = api.dispatch;
+    api.dispatch = (...a) => {
+      if (process.env.NODE_ENV !== "production" && a[0].type === "__setState" && !didWarnAboutReservedActionType) {
+        console.warn(
+          '[zustand devtools middleware] "__setState" action type is reserved to set state from the devtools. Avoid using it.'
+        );
+        didWarnAboutReservedActionType = true;
+      }
+      originalDispatch(...a);
+    };
+  }
+  connection.subscribe((message) => {
+    var _a;
+    switch (message.type) {
+      case "ACTION":
+        if (typeof message.payload !== "string") {
+          console.error(
+            "[zustand devtools middleware] Unsupported action format"
+          );
+          return;
+        }
+        return parseJsonThen(
+          message.payload,
+          (action) => {
+            if (action.type === "__setState") {
+              if (store === undefined) {
+                setStateFromDevtools(action.state);
+                return;
+              }
+              if (Object.keys(action.state).length !== 1) {
+                console.error(
+                  `
+                    [zustand devtools middleware] Unsupported __setState action format.
+                    When using 'store' option in devtools(), the 'state' should have only one key, which is a value of 'store' that was passed in devtools(),
+                    and value of this only key should be a state object. Example: { "type": "__setState", "state": { "abc123Store": { "foo": "bar" } } }
+                    `
+                );
+              }
+              const stateFromDevtools = action.state[store];
+              if (stateFromDevtools === undefined || stateFromDevtools === null) {
+                return;
+              }
+              if (JSON.stringify(api.getState()) !== JSON.stringify(stateFromDevtools)) {
+                setStateFromDevtools(stateFromDevtools);
+              }
+              return;
+            }
+            if (!api.dispatchFromDevtools) return;
+            if (typeof api.dispatch !== "function") return;
+            api.dispatch(action);
+          }
+        );
+      case "DISPATCH":
+        switch (message.payload.type) {
+          case "RESET":
+            setStateFromDevtools(initialState);
+            if (store === undefined) {
+              return connection == null ? undefined : connection.init(api.getState());
+            }
+            return connection == null ? undefined : connection.init(getTrackedConnectionState(options.name));
+          case "COMMIT":
+            if (store === undefined) {
+              connection == null ? undefined : connection.init(api.getState());
+              return;
+            }
+            return connection == null ? undefined : connection.init(getTrackedConnectionState(options.name));
+          case "ROLLBACK":
+            return parseJsonThen(message.state, (state) => {
+              if (store === undefined) {
+                setStateFromDevtools(state);
+                connection == null ? undefined : connection.init(api.getState());
+                return;
+              }
+              setStateFromDevtools(state[store]);
+              connection == null ? undefined : connection.init(getTrackedConnectionState(options.name));
+            });
+          case "JUMP_TO_STATE":
+          case "JUMP_TO_ACTION":
+            return parseJsonThen(message.state, (state) => {
+              if (store === undefined) {
+                setStateFromDevtools(state);
+                return;
+              }
+              if (JSON.stringify(api.getState()) !== JSON.stringify(state[store])) {
+                setStateFromDevtools(state[store]);
+              }
+            });
+          case "IMPORT_STATE": {
+            const { nextLiftedState } = message.payload;
+            const lastComputedState = (_a = nextLiftedState.computedStates.slice(-1)[0]) == null ? undefined : _a.state;
+            if (!lastComputedState) return;
+            if (store === undefined) {
+              setStateFromDevtools(lastComputedState);
+            } else {
+              setStateFromDevtools(lastComputedState[store]);
+            }
+            connection == null ? undefined : connection.send(
+              null,
+              // FIXME no-any
+              nextLiftedState
+            );
+            return;
+          }
+          case "PAUSE_RECORDING":
+            return isRecording = !isRecording;
+        }
+        return;
+    }
+  });
+  return initialState;
+};
+const devtools = devtoolsImpl;
+const parseJsonThen = (stringified, f) => {
+  let parsed;
+  try {
+    parsed = JSON.parse(stringified);
+  } catch (e) {
+    console.error(
+      "[zustand devtools middleware] Could not parse the received json",
+      e
+    );
+  }
+  if (parsed !== undefined) f(parsed);
+};
+
+const subscribeWithSelectorImpl = (fn) => (set, get, api) => {
+  const origSubscribe = api.subscribe;
+  api.subscribe = (selector, optListener, options) => {
+    let listener = selector;
+    if (optListener) {
+      const equalityFn = (options == null ? undefined : options.equalityFn) || Object.is;
+      let currentSlice = selector(api.getState());
+      listener = (state) => {
+        const nextSlice = selector(state);
+        if (!equalityFn(currentSlice, nextSlice)) {
+          const previousSlice = currentSlice;
+          optListener(currentSlice = nextSlice, previousSlice);
+        }
+      };
+      if (options == null ? undefined : options.fireImmediately) {
+        optListener(currentSlice, currentSlice);
+      }
+    }
+    return origSubscribe(listener);
+  };
+  const initialState = fn(set, get, api);
+  return initialState;
+};
+const subscribeWithSelector = subscribeWithSelectorImpl;
+
+const combine = (initialState, create) => (...a) => Object.assign({}, initialState, create(...a));
+
+function createJSONStorage(getStorage, options) {
+  let storage;
+  try {
+    storage = getStorage();
+  } catch (e) {
+    return;
+  }
+  const persistStorage = {
+    getItem: (name) => {
+      var _a;
+      const parse = (str2) => {
+        if (str2 === null) {
+          return null;
+        }
+        return JSON.parse(str2, options == null ? undefined : options.reviver);
+      };
+      const str = (_a = storage.getItem(name)) != null ? _a : null;
+      if (str instanceof Promise) {
+        return str.then(parse);
+      }
+      return parse(str);
+    },
+    setItem: (name, newValue) => storage.setItem(
+      name,
+      JSON.stringify(newValue, options == null ? undefined : options.replacer)
+    ),
+    removeItem: (name) => storage.removeItem(name)
+  };
+  return persistStorage;
+}
+const toThenable = (fn) => (input) => {
+  try {
+    const result = fn(input);
+    if (result instanceof Promise) {
+      return result;
+    }
+    return {
+      then(onFulfilled) {
+        return toThenable(onFulfilled)(result);
+      },
+      catch(_onRejected) {
+        return this;
+      }
+    };
+  } catch (e) {
+    return {
+      then(_onFulfilled) {
+        return this;
+      },
+      catch(onRejected) {
+        return toThenable(onRejected)(e);
+      }
+    };
+  }
+};
+const persistImpl = (config, baseOptions) => (set, get, api) => {
+  let options = {
+    storage: createJSONStorage(() => localStorage),
+    partialize: (state) => state,
+    version: 0,
+    merge: (persistedState, currentState) => ({
+      ...currentState,
+      ...persistedState
+    }),
+    ...baseOptions
+  };
+  let hasHydrated = false;
+  const hydrationListeners = /* @__PURE__ */ new Set();
+  const finishHydrationListeners = /* @__PURE__ */ new Set();
+  let storage = options.storage;
+  if (!storage) {
+    return config(
+      (...args) => {
+        console.warn(
+          `[zustand persist middleware] Unable to update item '${options.name}', the given storage is currently unavailable.`
+        );
+        set(...args);
+      },
+      get,
+      api
+    );
+  }
+  const setItem = () => {
+    const state = options.partialize({ ...get() });
+    return storage.setItem(options.name, {
+      state,
+      version: options.version
+    });
+  };
+  const savedSetState = api.setState;
+  api.setState = (state, replace) => {
+    savedSetState(state, replace);
+    void setItem();
+  };
+  const configResult = config(
+    (...args) => {
+      set(...args);
+      void setItem();
+    },
+    get,
+    api
+  );
+  api.getInitialState = () => configResult;
+  let stateFromStorage;
+  const hydrate = () => {
+    var _a, _b;
+    if (!storage) return;
+    hasHydrated = false;
+    hydrationListeners.forEach((cb) => {
+      var _a2;
+      return cb((_a2 = get()) != null ? _a2 : configResult);
+    });
+    const postRehydrationCallback = ((_b = options.onRehydrateStorage) == null ? undefined : _b.call(options, (_a = get()) != null ? _a : configResult)) || undefined;
+    return toThenable(storage.getItem.bind(storage))(options.name).then((deserializedStorageValue) => {
+      if (deserializedStorageValue) {
+        if (typeof deserializedStorageValue.version === "number" && deserializedStorageValue.version !== options.version) {
+          if (options.migrate) {
+            const migration = options.migrate(
+              deserializedStorageValue.state,
+              deserializedStorageValue.version
+            );
+            if (migration instanceof Promise) {
+              return migration.then((result) => [true, result]);
+            }
+            return [true, migration];
+          }
+          console.error(
+            `State loaded from storage couldn't be migrated since no migrate function was provided`
+          );
+        } else {
+          return [false, deserializedStorageValue.state];
+        }
+      }
+      return [false, undefined];
+    }).then((migrationResult) => {
+      var _a2;
+      const [migrated, migratedState] = migrationResult;
+      stateFromStorage = options.merge(
+        migratedState,
+        (_a2 = get()) != null ? _a2 : configResult
+      );
+      set(stateFromStorage, true);
+      if (migrated) {
+        return setItem();
+      }
+    }).then(() => {
+      postRehydrationCallback == null ? undefined : postRehydrationCallback(stateFromStorage, undefined);
+      stateFromStorage = get();
+      hasHydrated = true;
+      finishHydrationListeners.forEach((cb) => cb(stateFromStorage));
+    }).catch((e) => {
+      postRehydrationCallback == null ? undefined : postRehydrationCallback(undefined, e);
+    });
+  };
+  api.persist = {
+    setOptions: (newOptions) => {
+      options = {
+        ...options,
+        ...newOptions
+      };
+      if (newOptions.storage) {
+        storage = newOptions.storage;
+      }
+    },
+    clearStorage: () => {
+      storage == null ? undefined : storage.removeItem(options.name);
+    },
+    getOptions: () => options,
+    rehydrate: () => hydrate(),
+    hasHydrated: () => hasHydrated,
+    onHydrate: (cb) => {
+      hydrationListeners.add(cb);
+      return () => {
+        hydrationListeners.delete(cb);
+      };
+    },
+    onFinishHydration: (cb) => {
+      finishHydrationListeners.add(cb);
+      return () => {
+        finishHydrationListeners.delete(cb);
+      };
+    }
+  };
+  if (!options.skipHydration) {
+    hydrate();
+  }
+  return stateFromStorage || configResult;
+};
+const persist = persistImpl;
+
+exports.combine = combine;
+exports.createJSONStorage = createJSONStorage;
+exports.devtools = devtools;
+exports.persist = persist;
+exports.redux = redux;
+exports.subscribeWithSelector = subscribeWithSelector;

--- a/node_modules/zustand/middleware/combine.d.ts
+++ b/node_modules/zustand/middleware/combine.d.ts
@@ -1,0 +1,5 @@
+import type { StateCreator, StoreMutatorIdentifier } from 'zustand/vanilla';
+type Write<T, U> = Omit<T, keyof U> & U;
+type Combine = <T extends object, U extends object, Mps extends [StoreMutatorIdentifier, unknown][] = [], Mcs extends [StoreMutatorIdentifier, unknown][] = []>(initialState: T, additionalStateCreator: StateCreator<T, Mps, Mcs, U>) => StateCreator<Write<T, U>, Mps, Mcs>;
+export declare const combine: Combine;
+export {};

--- a/node_modules/zustand/middleware/devtools.d.ts
+++ b/node_modules/zustand/middleware/devtools.d.ts
@@ -1,0 +1,55 @@
+import type { StateCreator, StoreApi, StoreMutatorIdentifier } from 'zustand/vanilla';
+type Config = Parameters<(Window extends {
+    __REDUX_DEVTOOLS_EXTENSION__?: infer T;
+} ? T : {
+    connect: (param: any) => any;
+})['connect']>[0];
+declare module '../vanilla' {
+    interface StoreMutators<S, A> {
+        'zustand/devtools': WithDevtools<S>;
+    }
+}
+type Cast<T, U> = T extends U ? T : U;
+type Write<T, U> = Omit<T, keyof U> & U;
+type TakeTwo<T> = T extends {
+    length: 0;
+} ? [undefined, undefined] : T extends {
+    length: 1;
+} ? [...a0: Cast<T, unknown[]>, a1: undefined] : T extends {
+    length: 0 | 1;
+} ? [...a0: Cast<T, unknown[]>, a1: undefined] : T extends {
+    length: 2;
+} ? T : T extends {
+    length: 1 | 2;
+} ? T : T extends {
+    length: 0 | 1 | 2;
+} ? T : T extends [infer A0, infer A1, ...unknown[]] ? [A0, A1] : T extends [infer A0, (infer A1)?, ...unknown[]] ? [A0, A1?] : T extends [(infer A0)?, (infer A1)?, ...unknown[]] ? [A0?, A1?] : never;
+type WithDevtools<S> = Write<S, StoreDevtools<S>>;
+type Action = string | {
+    type: string;
+    [x: string | number | symbol]: unknown;
+};
+type StoreDevtools<S> = S extends {
+    setState: {
+        (...a: infer Sa1): infer Sr1;
+        (...a: infer Sa2): infer Sr2;
+    };
+} ? {
+    setState(...a: [...a: TakeTwo<Sa1>, action?: Action]): Sr1;
+    setState(...a: [...a: TakeTwo<Sa2>, action?: Action]): Sr2;
+} : never;
+export interface DevtoolsOptions extends Config {
+    name?: string;
+    enabled?: boolean;
+    anonymousActionType?: string;
+    store?: string;
+}
+type Devtools = <T, Mps extends [StoreMutatorIdentifier, unknown][] = [], Mcs extends [StoreMutatorIdentifier, unknown][] = [], U = T>(initializer: StateCreator<T, [...Mps, ['zustand/devtools', never]], Mcs, U>, devtoolsOptions?: DevtoolsOptions) => StateCreator<T, Mps, [['zustand/devtools', never], ...Mcs]>;
+declare module '../vanilla' {
+    interface StoreMutators<S, A> {
+        'zustand/devtools': WithDevtools<S>;
+    }
+}
+export type NamedSet<T> = WithDevtools<StoreApi<T>>['setState'];
+export declare const devtools: Devtools;
+export {};

--- a/node_modules/zustand/middleware/immer.d.ts
+++ b/node_modules/zustand/middleware/immer.d.ts
@@ -1,0 +1,29 @@
+import type { Draft } from 'immer';
+import type { StateCreator, StoreMutatorIdentifier } from 'zustand/vanilla';
+type Immer = <T, Mps extends [StoreMutatorIdentifier, unknown][] = [], Mcs extends [StoreMutatorIdentifier, unknown][] = []>(initializer: StateCreator<T, [...Mps, ['zustand/immer', never]], Mcs>) => StateCreator<T, Mps, [['zustand/immer', never], ...Mcs]>;
+declare module '../vanilla' {
+    interface StoreMutators<S, A> {
+        ['zustand/immer']: WithImmer<S>;
+    }
+}
+type Write<T, U> = Omit<T, keyof U> & U;
+type SkipTwo<T> = T extends {
+    length: 0;
+} ? [] : T extends {
+    length: 1;
+} ? [] : T extends {
+    length: 0 | 1;
+} ? [] : T extends [unknown, unknown, ...infer A] ? A : T extends [unknown, unknown?, ...infer A] ? A : T extends [unknown?, unknown?, ...infer A] ? A : never;
+type SetStateType<T extends unknown[]> = Exclude<T[0], (...args: any[]) => any>;
+type WithImmer<S> = Write<S, StoreImmer<S>>;
+type StoreImmer<S> = S extends {
+    setState: infer SetState;
+} ? SetState extends {
+    (...a: infer A1): infer Sr1;
+    (...a: infer A2): infer Sr2;
+} ? {
+    setState(nextStateOrUpdater: SetStateType<A2> | Partial<SetStateType<A2>> | ((state: Draft<SetStateType<A2>>) => void), shouldReplace?: false, ...a: SkipTwo<A1>): Sr1;
+    setState(nextStateOrUpdater: SetStateType<A2> | ((state: Draft<SetStateType<A2>>) => void), shouldReplace: true, ...a: SkipTwo<A2>): Sr2;
+} : never : never;
+export declare const immer: Immer;
+export {};

--- a/node_modules/zustand/middleware/immer.js
+++ b/node_modules/zustand/middleware/immer.js
@@ -1,0 +1,14 @@
+'use strict';
+
+var immer$1 = require('immer');
+
+const immerImpl = (initializer) => (set, get, store) => {
+  store.setState = (updater, replace, ...a) => {
+    const nextState = typeof updater === "function" ? immer$1.produce(updater) : updater;
+    return set(nextState, replace, ...a);
+  };
+  return initializer(store.setState, get, store);
+};
+const immer = immerImpl;
+
+exports.immer = immer;

--- a/node_modules/zustand/middleware/persist.d.ts
+++ b/node_modules/zustand/middleware/persist.d.ts
@@ -1,0 +1,93 @@
+import type { StateCreator, StoreMutatorIdentifier } from 'zustand/vanilla';
+export interface StateStorage {
+    getItem: (name: string) => string | null | Promise<string | null>;
+    setItem: (name: string, value: string) => unknown | Promise<unknown>;
+    removeItem: (name: string) => unknown | Promise<unknown>;
+}
+export type StorageValue<S> = {
+    state: S;
+    version?: number;
+};
+export interface PersistStorage<S> {
+    getItem: (name: string) => StorageValue<S> | null | Promise<StorageValue<S> | null>;
+    setItem: (name: string, value: StorageValue<S>) => unknown | Promise<unknown>;
+    removeItem: (name: string) => unknown | Promise<unknown>;
+}
+type JsonStorageOptions = {
+    reviver?: (key: string, value: unknown) => unknown;
+    replacer?: (key: string, value: unknown) => unknown;
+};
+export declare function createJSONStorage<S>(getStorage: () => StateStorage, options?: JsonStorageOptions): PersistStorage<S> | undefined;
+export interface PersistOptions<S, PersistedState = S> {
+    /** Name of the storage (must be unique) */
+    name: string;
+    /**
+     * Use a custom persist storage.
+     *
+     * Combining `createJSONStorage` helps creating a persist storage
+     * with JSON.parse and JSON.stringify.
+     *
+     * @default createJSONStorage(() => localStorage)
+     */
+    storage?: PersistStorage<PersistedState> | undefined;
+    /**
+     * Filter the persisted value.
+     *
+     * @params state The state's value
+     */
+    partialize?: (state: S) => PersistedState;
+    /**
+     * A function returning another (optional) function.
+     * The main function will be called before the state rehydration.
+     * The returned function will be called after the state rehydration or when an error occurred.
+     */
+    onRehydrateStorage?: (state: S) => ((state?: S, error?: unknown) => void) | void;
+    /**
+     * If the stored state's version mismatch the one specified here, the storage will not be used.
+     * This is useful when adding a breaking change to your store.
+     */
+    version?: number;
+    /**
+     * A function to perform persisted state migration.
+     * This function will be called when persisted state versions mismatch with the one specified here.
+     */
+    migrate?: (persistedState: unknown, version: number) => PersistedState | Promise<PersistedState>;
+    /**
+     * A function to perform custom hydration merges when combining the stored state with the current one.
+     * By default, this function does a shallow merge.
+     */
+    merge?: (persistedState: unknown, currentState: S) => S;
+    /**
+     * An optional boolean that will prevent the persist middleware from triggering hydration on initialization,
+     * This allows you to call `rehydrate()` at a specific point in your apps rendering life-cycle.
+     *
+     * This is useful in SSR application.
+     *
+     * @default false
+     */
+    skipHydration?: boolean;
+}
+type PersistListener<S> = (state: S) => void;
+type StorePersist<S, Ps> = {
+    persist: {
+        setOptions: (options: Partial<PersistOptions<S, Ps>>) => void;
+        clearStorage: () => void;
+        rehydrate: () => Promise<void> | void;
+        hasHydrated: () => boolean;
+        onHydrate: (fn: PersistListener<S>) => () => void;
+        onFinishHydration: (fn: PersistListener<S>) => () => void;
+        getOptions: () => Partial<PersistOptions<S, Ps>>;
+    };
+};
+type Persist = <T, Mps extends [StoreMutatorIdentifier, unknown][] = [], Mcs extends [StoreMutatorIdentifier, unknown][] = [], U = T>(initializer: StateCreator<T, [...Mps, ['zustand/persist', unknown]], Mcs>, options: PersistOptions<T, U>) => StateCreator<T, Mps, [['zustand/persist', U], ...Mcs]>;
+declare module '../vanilla' {
+    interface StoreMutators<S, A> {
+        'zustand/persist': WithPersist<S, A>;
+    }
+}
+type Write<T, U> = Omit<T, keyof U> & U;
+type WithPersist<S, A> = S extends {
+    getState: () => infer T;
+} ? Write<S, StorePersist<T, A>> : never;
+export declare const persist: Persist;
+export {};

--- a/node_modules/zustand/middleware/redux.d.ts
+++ b/node_modules/zustand/middleware/redux.d.ts
@@ -1,0 +1,21 @@
+import type { StateCreator, StoreMutatorIdentifier } from 'zustand/vanilla';
+type Write<T, U> = Omit<T, keyof U> & U;
+type Action = {
+    type: string;
+};
+type StoreRedux<A> = {
+    dispatch: (a: A) => A;
+    dispatchFromDevtools: true;
+};
+type ReduxState<A> = {
+    dispatch: StoreRedux<A>['dispatch'];
+};
+type WithRedux<S, A> = Write<S, StoreRedux<A>>;
+type Redux = <T, A extends Action, Cms extends [StoreMutatorIdentifier, unknown][] = []>(reducer: (state: T, action: A) => T, initialState: T) => StateCreator<Write<T, ReduxState<A>>, Cms, [['zustand/redux', A]]>;
+declare module '../vanilla' {
+    interface StoreMutators<S, A> {
+        'zustand/redux': WithRedux<S, A>;
+    }
+}
+export declare const redux: Redux;
+export {};

--- a/node_modules/zustand/middleware/subscribeWithSelector.d.ts
+++ b/node_modules/zustand/middleware/subscribeWithSelector.d.ts
@@ -1,0 +1,25 @@
+import type { StateCreator, StoreMutatorIdentifier } from 'zustand/vanilla';
+type SubscribeWithSelector = <T, Mps extends [StoreMutatorIdentifier, unknown][] = [], Mcs extends [StoreMutatorIdentifier, unknown][] = []>(initializer: StateCreator<T, [
+    ...Mps,
+    ['zustand/subscribeWithSelector', never]
+], Mcs>) => StateCreator<T, Mps, [['zustand/subscribeWithSelector', never], ...Mcs]>;
+type Write<T, U> = Omit<T, keyof U> & U;
+type WithSelectorSubscribe<S> = S extends {
+    getState: () => infer T;
+} ? Write<S, StoreSubscribeWithSelector<T>> : never;
+declare module '../vanilla' {
+    interface StoreMutators<S, A> {
+        ['zustand/subscribeWithSelector']: WithSelectorSubscribe<S>;
+    }
+}
+type StoreSubscribeWithSelector<T> = {
+    subscribe: {
+        (listener: (selectedState: T, previousSelectedState: T) => void): () => void;
+        <U>(selector: (state: T) => U, listener: (selectedState: U, previousSelectedState: U) => void, options?: {
+            equalityFn?: (a: U, b: U) => boolean;
+            fireImmediately?: boolean;
+        }): () => void;
+    };
+};
+export declare const subscribeWithSelector: SubscribeWithSelector;
+export {};

--- a/node_modules/zustand/package.json
+++ b/node_modules/zustand/package.json
@@ -1,0 +1,100 @@
+{
+  "name": "zustand",
+  "description": "🐻 Bear necessities for state management in React",
+  "private": false,
+  "type": "commonjs",
+  "version": "5.0.3",
+  "main": "./index.js",
+  "types": "./index.d.ts",
+  "typesVersions": {
+    ">=4.5": {
+      "esm/*": [
+        "esm/*"
+      ],
+      "*": [
+        "*"
+      ]
+    },
+    "*": {
+      "esm/*": [
+        "ts_version_4.5_and_above_is_required.d.ts"
+      ],
+      "*": [
+        "ts_version_4.5_and_above_is_required.d.ts"
+      ]
+    }
+  },
+  "exports": {
+    "./package.json": "./package.json",
+    ".": {
+      "import": {
+        "types": "./esm/index.d.mts",
+        "default": "./esm/index.mjs"
+      },
+      "default": {
+        "types": "./index.d.ts",
+        "default": "./index.js"
+      }
+    },
+    "./*": {
+      "import": {
+        "types": "./esm/*.d.mts",
+        "default": "./esm/*.mjs"
+      },
+      "default": {
+        "types": "./*.d.ts",
+        "default": "./*.js"
+      }
+    }
+  },
+  "files": [
+    "**"
+  ],
+  "sideEffects": false,
+  "engines": {
+    "node": ">=12.20.0"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/pmndrs/zustand.git"
+  },
+  "keywords": [
+    "react",
+    "state",
+    "manager",
+    "management",
+    "redux",
+    "store"
+  ],
+  "author": "Paul Henschel",
+  "contributors": [
+    "Jeremy Holcomb (https://github.com/JeremyRH)",
+    "Daishi Kato (https://github.com/dai-shi)"
+  ],
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/pmndrs/zustand/issues"
+  },
+  "homepage": "https://github.com/pmndrs/zustand",
+  "packageManager": "pnpm@8.15.0",
+  "peerDependencies": {
+    "@types/react": ">=18.0.0",
+    "immer": ">=9.0.6",
+    "react": ">=18.0.0",
+    "use-sync-external-store": ">=1.2.0"
+  },
+  "peerDependenciesMeta": {
+    "@types/react": {
+      "optional": true
+    },
+    "immer": {
+      "optional": true
+    },
+    "react": {
+      "optional": true
+    },
+    "use-sync-external-store": {
+      "optional": true
+    }
+  }
+}

--- a/node_modules/zustand/react.d.ts
+++ b/node_modules/zustand/react.d.ts
@@ -1,0 +1,14 @@
+import type { ExtractState, Mutate, StateCreator, StoreApi, StoreMutatorIdentifier } from 'zustand/vanilla';
+type ReadonlyStoreApi<T> = Pick<StoreApi<T>, 'getState' | 'getInitialState' | 'subscribe'>;
+export declare function useStore<S extends ReadonlyStoreApi<unknown>>(api: S): ExtractState<S>;
+export declare function useStore<S extends ReadonlyStoreApi<unknown>, U>(api: S, selector: (state: ExtractState<S>) => U): U;
+export type UseBoundStore<S extends ReadonlyStoreApi<unknown>> = {
+    (): ExtractState<S>;
+    <U>(selector: (state: ExtractState<S>) => U): U;
+} & S;
+type Create = {
+    <T, Mos extends [StoreMutatorIdentifier, unknown][] = []>(initializer: StateCreator<T, [], Mos>): UseBoundStore<Mutate<StoreApi<T>, Mos>>;
+    <T>(): <Mos extends [StoreMutatorIdentifier, unknown][] = []>(initializer: StateCreator<T, [], Mos>) => UseBoundStore<Mutate<StoreApi<T>, Mos>>;
+};
+export declare const create: Create;
+export {};

--- a/node_modules/zustand/react.js
+++ b/node_modules/zustand/react.js
@@ -1,0 +1,25 @@
+'use strict';
+
+var React = require('react');
+var vanilla = require('zustand/vanilla');
+
+const identity = (arg) => arg;
+function useStore(api, selector = identity) {
+  const slice = React.useSyncExternalStore(
+    api.subscribe,
+    () => selector(api.getState()),
+    () => selector(api.getInitialState())
+  );
+  React.useDebugValue(slice);
+  return slice;
+}
+const createImpl = (createState) => {
+  const api = vanilla.createStore(createState);
+  const useBoundStore = (selector) => useStore(api, selector);
+  Object.assign(useBoundStore, api);
+  return useBoundStore;
+};
+const create = (createState) => createState ? createImpl(createState) : createImpl;
+
+exports.create = create;
+exports.useStore = useStore;

--- a/node_modules/zustand/react/shallow.d.ts
+++ b/node_modules/zustand/react/shallow.d.ts
@@ -1,0 +1,1 @@
+export declare function useShallow<S, U>(selector: (state: S) => U): (state: S) => U;

--- a/node_modules/zustand/react/shallow.js
+++ b/node_modules/zustand/react/shallow.js
@@ -1,0 +1,14 @@
+'use strict';
+
+var React = require('react');
+var shallow = require('zustand/vanilla/shallow');
+
+function useShallow(selector) {
+  const prev = React.useRef(undefined);
+  return (state) => {
+    const next = selector(state);
+    return shallow.shallow(prev.current, next) ? prev.current : prev.current = next;
+  };
+}
+
+exports.useShallow = useShallow;

--- a/node_modules/zustand/readme.md
+++ b/node_modules/zustand/readme.md
@@ -1,0 +1,508 @@
+<p align="center">
+  <img src="docs/bear.jpg" />
+</p>
+
+[![Build Status](https://img.shields.io/github/actions/workflow/status/pmndrs/zustand/lint-and-type.yml?branch=main&style=flat&colorA=000000&colorB=000000)](https://github.com/pmndrs/zustand/actions?query=workflow%3ALint)
+[![Build Size](https://img.shields.io/bundlephobia/minzip/zustand?label=bundle%20size&style=flat&colorA=000000&colorB=000000)](https://bundlephobia.com/result?p=zustand)
+[![Version](https://img.shields.io/npm/v/zustand?style=flat&colorA=000000&colorB=000000)](https://www.npmjs.com/package/zustand)
+[![Downloads](https://img.shields.io/npm/dt/zustand.svg?style=flat&colorA=000000&colorB=000000)](https://www.npmjs.com/package/zustand)
+[![Discord Shield](https://img.shields.io/discord/740090768164651008?style=flat&colorA=000000&colorB=000000&label=discord&logo=discord&logoColor=ffffff)](https://discord.gg/poimandres)
+
+A small, fast and scalable bearbones state-management solution using simplified flux principles. Has a comfy API based on hooks, isn't boilerplatey or opinionated.
+
+Don't disregard it because it's cute. It has quite the claws, lots of time was spent dealing with common pitfalls, like the dreaded [zombie child problem](https://react-redux.js.org/api/hooks#stale-props-and-zombie-children), [react concurrency](https://github.com/bvaughn/rfcs/blob/useMutableSource/text/0000-use-mutable-source.md), and [context loss](https://github.com/facebook/react/issues/13332) between mixed renderers. It may be the one state-manager in the React space that gets all of these right.
+
+You can try a live demo [here](https://githubbox.com/pmndrs/zustand/tree/main/examples/demo).
+
+```bash
+npm install zustand
+```
+
+:warning: This readme is written for JavaScript users. If you are a TypeScript user, be sure to check out our [TypeScript Usage section](#typescript-usage).
+
+## First create a store
+
+Your store is a hook! You can put anything in it: primitives, objects, functions. State has to be updated immutably and the `set` function [merges state](./docs/guides/immutable-state-and-merging.md) to help it.
+
+```jsx
+import { create } from 'zustand'
+
+const useBearStore = create((set) => ({
+  bears: 0,
+  increasePopulation: () => set((state) => ({ bears: state.bears + 1 })),
+  removeAllBears: () => set({ bears: 0 }),
+}))
+```
+
+## Then bind your components, and that's it!
+
+Use the hook anywhere, no providers are needed. Select your state and the component will re-render on changes.
+
+```jsx
+function BearCounter() {
+  const bears = useBearStore((state) => state.bears)
+  return <h1>{bears} around here ...</h1>
+}
+
+function Controls() {
+  const increasePopulation = useBearStore((state) => state.increasePopulation)
+  return <button onClick={increasePopulation}>one up</button>
+}
+```
+
+### Why zustand over redux?
+
+- Simple and un-opinionated
+- Makes hooks the primary means of consuming state
+- Doesn't wrap your app in context providers
+- [Can inform components transiently (without causing render)](#transient-updates-for-often-occurring-state-changes)
+
+### Why zustand over context?
+
+- Less boilerplate
+- Renders components only on changes
+- Centralized, action-based state management
+
+---
+
+# Recipes
+
+## Fetching everything
+
+You can, but bear in mind that it will cause the component to update on every state change!
+
+```jsx
+const state = useBearStore()
+```
+
+## Selecting multiple state slices
+
+It detects changes with strict-equality (old === new) by default, this is efficient for atomic state picks.
+
+```jsx
+const nuts = useBearStore((state) => state.nuts)
+const honey = useBearStore((state) => state.honey)
+```
+
+If you want to construct a single object with multiple state-picks inside, similar to redux's mapStateToProps, you can use [useShallow](./docs/guides/prevent-rerenders-with-use-shallow.md) to prevent unnecessary rerenders when the selector output does not change according to shallow equal.
+
+```jsx
+import { create } from 'zustand'
+import { useShallow } from 'zustand/react/shallow'
+
+const useBearStore = create((set) => ({
+  nuts: 0,
+  honey: 0,
+  treats: {},
+  // ...
+}))
+
+// Object pick, re-renders the component when either state.nuts or state.honey change
+const { nuts, honey } = useBearStore(
+  useShallow((state) => ({ nuts: state.nuts, honey: state.honey })),
+)
+
+// Array pick, re-renders the component when either state.nuts or state.honey change
+const [nuts, honey] = useBearStore(
+  useShallow((state) => [state.nuts, state.honey]),
+)
+
+// Mapped picks, re-renders the component when state.treats changes in order, count or keys
+const treats = useBearStore(useShallow((state) => Object.keys(state.treats)))
+```
+
+For more control over re-rendering, you may provide any custom equality function (this example requires the use of [`createWithEqualityFn`](./docs/migrations/migrating-to-v5.md#using-custom-equality-functions-such-as-shallow)).
+
+```jsx
+const treats = useBearStore(
+  (state) => state.treats,
+  (oldTreats, newTreats) => compare(oldTreats, newTreats),
+)
+```
+
+## Overwriting state
+
+The `set` function has a second argument, `false` by default. Instead of merging, it will replace the state model. Be careful not to wipe out parts you rely on, like actions.
+
+```jsx
+import omit from 'lodash-es/omit'
+
+const useFishStore = create((set) => ({
+  salmon: 1,
+  tuna: 2,
+  deleteEverything: () => set({}, true), // clears the entire store, actions included
+  deleteTuna: () => set((state) => omit(state, ['tuna']), true),
+}))
+```
+
+## Async actions
+
+Just call `set` when you're ready, zustand doesn't care if your actions are async or not.
+
+```jsx
+const useFishStore = create((set) => ({
+  fishies: {},
+  fetch: async (pond) => {
+    const response = await fetch(pond)
+    set({ fishies: await response.json() })
+  },
+}))
+```
+
+## Read from state in actions
+
+`set` allows fn-updates `set(state => result)`, but you still have access to state outside of it through `get`.
+
+```jsx
+const useSoundStore = create((set, get) => ({
+  sound: 'grunt',
+  action: () => {
+    const sound = get().sound
+    ...
+```
+
+## Reading/writing state and reacting to changes outside of components
+
+Sometimes you need to access state in a non-reactive way or act upon the store. For these cases, the resulting hook has utility functions attached to its prototype.
+
+:warning: This technique is not recommended for adding state in [React Server Components](https://github.com/reactjs/rfcs/blob/main/text/0188-server-components.md) (typically in Next.js 13 and above). It can lead to unexpected bugs and privacy issues for your users. For more details, see [#2200](https://github.com/pmndrs/zustand/discussions/2200).
+
+```jsx
+const useDogStore = create(() => ({ paw: true, snout: true, fur: true }))
+
+// Getting non-reactive fresh state
+const paw = useDogStore.getState().paw
+// Listening to all changes, fires synchronously on every change
+const unsub1 = useDogStore.subscribe(console.log)
+// Updating state, will trigger listeners
+useDogStore.setState({ paw: false })
+// Unsubscribe listeners
+unsub1()
+
+// You can of course use the hook as you always would
+function Component() {
+  const paw = useDogStore((state) => state.paw)
+  ...
+```
+
+### Using subscribe with selector
+
+If you need to subscribe with a selector,
+`subscribeWithSelector` middleware will help.
+
+With this middleware `subscribe` accepts an additional signature:
+
+```ts
+subscribe(selector, callback, options?: { equalityFn, fireImmediately }): Unsubscribe
+```
+
+```js
+import { subscribeWithSelector } from 'zustand/middleware'
+const useDogStore = create(
+  subscribeWithSelector(() => ({ paw: true, snout: true, fur: true })),
+)
+
+// Listening to selected changes, in this case when "paw" changes
+const unsub2 = useDogStore.subscribe((state) => state.paw, console.log)
+// Subscribe also exposes the previous value
+const unsub3 = useDogStore.subscribe(
+  (state) => state.paw,
+  (paw, previousPaw) => console.log(paw, previousPaw),
+)
+// Subscribe also supports an optional equality function
+const unsub4 = useDogStore.subscribe(
+  (state) => [state.paw, state.fur],
+  console.log,
+  { equalityFn: shallow },
+)
+// Subscribe and fire immediately
+const unsub5 = useDogStore.subscribe((state) => state.paw, console.log, {
+  fireImmediately: true,
+})
+```
+
+## Using zustand without React
+
+Zustand core can be imported and used without the React dependency. The only difference is that the create function does not return a hook, but the API utilities.
+
+```jsx
+import { createStore } from 'zustand/vanilla'
+
+const store = createStore((set) => ...)
+const { getState, setState, subscribe, getInitialState } = store
+
+export default store
+```
+
+You can use a vanilla store with `useStore` hook available since v4.
+
+```jsx
+import { useStore } from 'zustand'
+import { vanillaStore } from './vanillaStore'
+
+const useBoundStore = (selector) => useStore(vanillaStore, selector)
+```
+
+:warning: Note that middlewares that modify `set` or `get` are not applied to `getState` and `setState`.
+
+## Transient updates (for often occurring state-changes)
+
+The subscribe function allows components to bind to a state-portion without forcing re-render on changes. Best combine it with useEffect for automatic unsubscribe on unmount. This can make a [drastic](https://codesandbox.io/s/peaceful-johnson-txtws) performance impact when you are allowed to mutate the view directly.
+
+```jsx
+const useScratchStore = create((set) => ({ scratches: 0, ... }))
+
+const Component = () => {
+  // Fetch initial state
+  const scratchRef = useRef(useScratchStore.getState().scratches)
+  // Connect to the store on mount, disconnect on unmount, catch state-changes in a reference
+  useEffect(() => useScratchStore.subscribe(
+    state => (scratchRef.current = state.scratches)
+  ), [])
+  ...
+```
+
+## Sick of reducers and changing nested states? Use Immer!
+
+Reducing nested structures is tiresome. Have you tried [immer](https://github.com/mweststrate/immer)?
+
+```jsx
+import { produce } from 'immer'
+
+const useLushStore = create((set) => ({
+  lush: { forest: { contains: { a: 'bear' } } },
+  clearForest: () =>
+    set(
+      produce((state) => {
+        state.lush.forest.contains = null
+      }),
+    ),
+}))
+
+const clearForest = useLushStore((state) => state.clearForest)
+clearForest()
+```
+
+[Alternatively, there are some other solutions.](./docs/guides/updating-state.md#with-immer)
+
+## Persist middleware
+
+You can persist your store's data using any kind of storage.
+
+```jsx
+import { create } from 'zustand'
+import { persist, createJSONStorage } from 'zustand/middleware'
+
+const useFishStore = create(
+  persist(
+    (set, get) => ({
+      fishes: 0,
+      addAFish: () => set({ fishes: get().fishes + 1 }),
+    }),
+    {
+      name: 'food-storage', // name of the item in the storage (must be unique)
+      storage: createJSONStorage(() => sessionStorage), // (optional) by default, 'localStorage' is used
+    },
+  ),
+)
+```
+
+[See the full documentation for this middleware.](./docs/integrations/persisting-store-data.md)
+
+## Immer middleware
+
+Immer is available as middleware too.
+
+```jsx
+import { create } from 'zustand'
+import { immer } from 'zustand/middleware/immer'
+
+const useBeeStore = create(
+  immer((set) => ({
+    bees: 0,
+    addBees: (by) =>
+      set((state) => {
+        state.bees += by
+      }),
+  })),
+)
+```
+
+## Can't live without redux-like reducers and action types?
+
+```jsx
+const types = { increase: 'INCREASE', decrease: 'DECREASE' }
+
+const reducer = (state, { type, by = 1 }) => {
+  switch (type) {
+    case types.increase:
+      return { grumpiness: state.grumpiness + by }
+    case types.decrease:
+      return { grumpiness: state.grumpiness - by }
+  }
+}
+
+const useGrumpyStore = create((set) => ({
+  grumpiness: 0,
+  dispatch: (args) => set((state) => reducer(state, args)),
+}))
+
+const dispatch = useGrumpyStore((state) => state.dispatch)
+dispatch({ type: types.increase, by: 2 })
+```
+
+Or, just use our redux-middleware. It wires up your main-reducer, sets the initial state, and adds a dispatch function to the state itself and the vanilla API.
+
+```jsx
+import { redux } from 'zustand/middleware'
+
+const useGrumpyStore = create(redux(reducer, initialState))
+```
+
+## Redux devtools
+
+Install the [Redux DevTools Chrome extension](https://chromewebstore.google.com/detail/redux-devtools/lmhkpmbekcpmknklioeibfkpmmfibljd) to use the devtools middleware.
+
+```jsx
+import { devtools } from 'zustand/middleware'
+
+// Usage with a plain action store, it will log actions as "setState"
+const usePlainStore = create(devtools((set) => ...))
+// Usage with a redux store, it will log full action types
+const useReduxStore = create(devtools(redux(reducer, initialState)))
+```
+
+One redux devtools connection for multiple stores
+
+```jsx
+import { devtools } from 'zustand/middleware'
+
+// Usage with a plain action store, it will log actions as "setState"
+const usePlainStore1 = create(devtools((set) => ..., { name, store: storeName1 }))
+const usePlainStore2 = create(devtools((set) => ..., { name, store: storeName2 }))
+// Usage with a redux store, it will log full action types
+const useReduxStore = create(devtools(redux(reducer, initialState)), , { name, store: storeName3 })
+const useReduxStore = create(devtools(redux(reducer, initialState)), , { name, store: storeName4 })
+```
+
+Assigning different connection names will separate stores in redux devtools. This also helps group different stores into separate redux devtools connections.
+
+devtools takes the store function as its first argument, optionally you can name the store or configure [serialize](https://github.com/zalmoxisus/redux-devtools-extension/blob/master/docs/API/Arguments.md#serialize) options with a second argument.
+
+Name store: `devtools(..., {name: "MyStore"})`, which will create a separate instance named "MyStore" in the devtools.
+
+Serialize options: `devtools(..., { serialize: { options: true } })`.
+
+#### Logging Actions
+
+devtools will only log actions from each separated store unlike in a typical _combined reducers_ redux store. See an approach to combining stores https://github.com/pmndrs/zustand/issues/163
+
+You can log a specific action type for each `set` function by passing a third parameter:
+
+```jsx
+const useBearStore = create(devtools((set) => ({
+  ...
+  eatFish: () => set(
+    (prev) => ({ fishes: prev.fishes > 1 ? prev.fishes - 1 : 0 }),
+    undefined,
+    'bear/eatFish'
+  ),
+  ...
+```
+
+You can also log the action's type along with its payload:
+
+```jsx
+  ...
+  addFishes: (count) => set(
+    (prev) => ({ fishes: prev.fishes + count }),
+    undefined,
+    { type: 'bear/addFishes', count, }
+  ),
+  ...
+```
+
+If an action type is not provided, it is defaulted to "anonymous". You can customize this default value by providing an `anonymousActionType` parameter:
+
+```jsx
+devtools(..., { anonymousActionType: 'unknown', ... })
+```
+
+If you wish to disable devtools (on production for instance). You can customize this setting by providing the `enabled` parameter:
+
+```jsx
+devtools(..., { enabled: false, ... })
+```
+
+## React context
+
+The store created with `create` doesn't require context providers. In some cases, you may want to use contexts for dependency injection or if you want to initialize your store with props from a component. Because the normal store is a hook, passing it as a normal context value may violate the rules of hooks.
+
+The recommended method available since v4 is to use the vanilla store.
+
+```jsx
+import { createContext, useContext } from 'react'
+import { createStore, useStore } from 'zustand'
+
+const store = createStore(...) // vanilla store without hooks
+
+const StoreContext = createContext()
+
+const App = () => (
+  <StoreContext.Provider value={store}>
+    ...
+  </StoreContext.Provider>
+)
+
+const Component = () => {
+  const store = useContext(StoreContext)
+  const slice = useStore(store, selector)
+  ...
+```
+
+## TypeScript Usage
+
+Basic typescript usage doesn't require anything special except for writing `create<State>()(...)` instead of `create(...)`...
+
+```ts
+import { create } from 'zustand'
+import { devtools, persist } from 'zustand/middleware'
+import type {} from '@redux-devtools/extension' // required for devtools typing
+
+interface BearState {
+  bears: number
+  increase: (by: number) => void
+}
+
+const useBearStore = create<BearState>()(
+  devtools(
+    persist(
+      (set) => ({
+        bears: 0,
+        increase: (by) => set((state) => ({ bears: state.bears + by })),
+      }),
+      {
+        name: 'bear-storage',
+      },
+    ),
+  ),
+)
+```
+
+A more complete TypeScript guide is [here](docs/guides/typescript.md).
+
+## Best practices
+
+- You may wonder how to organize your code for better maintenance: [Splitting the store into separate slices](./docs/guides/slices-pattern.md).
+- Recommended usage for this unopinionated library: [Flux inspired practice](./docs/guides/flux-inspired-practice.md).
+- [Calling actions outside a React event handler in pre-React 18](./docs/guides/event-handler-in-pre-react-18.md).
+- [Testing](./docs/guides/testing.md)
+- For more, have a look [in the docs folder](./docs/)
+
+## Third-Party Libraries
+
+Some users may want to extend Zustand's feature set which can be done using third-party libraries made by the community. For information regarding third-party libraries with Zustand, visit [the doc](./docs/integrations/third-party-libraries.md).
+
+## Comparison with other libraries
+
+- [Difference between zustand and other state management libraries for React](https://docs.pmnd.rs/zustand/getting-started/comparison)

--- a/node_modules/zustand/shallow.d.ts
+++ b/node_modules/zustand/shallow.d.ts
@@ -1,0 +1,2 @@
+export { shallow } from 'zustand/vanilla/shallow';
+export { useShallow } from 'zustand/react/shallow';

--- a/node_modules/zustand/shallow.js
+++ b/node_modules/zustand/shallow.js
@@ -1,0 +1,15 @@
+'use strict';
+
+var shallow = require('zustand/vanilla/shallow');
+var shallow$1 = require('zustand/react/shallow');
+
+
+
+Object.defineProperty(exports, "shallow", {
+	enumerable: true,
+	get: function () { return shallow.shallow; }
+});
+Object.defineProperty(exports, "useShallow", {
+	enumerable: true,
+	get: function () { return shallow$1.useShallow; }
+});

--- a/node_modules/zustand/traditional.d.ts
+++ b/node_modules/zustand/traditional.d.ts
@@ -1,0 +1,17 @@
+import type { Mutate, StateCreator, StoreApi, StoreMutatorIdentifier } from 'zustand/vanilla';
+type ExtractState<S> = S extends {
+    getState: () => infer T;
+} ? T : never;
+type ReadonlyStoreApi<T> = Pick<StoreApi<T>, 'getState' | 'getInitialState' | 'subscribe'>;
+export declare function useStoreWithEqualityFn<S extends ReadonlyStoreApi<unknown>>(api: S): ExtractState<S>;
+export declare function useStoreWithEqualityFn<S extends ReadonlyStoreApi<unknown>, U>(api: S, selector: (state: ExtractState<S>) => U, equalityFn?: (a: U, b: U) => boolean): U;
+export type UseBoundStoreWithEqualityFn<S extends ReadonlyStoreApi<unknown>> = {
+    (): ExtractState<S>;
+    <U>(selector: (state: ExtractState<S>) => U, equalityFn?: (a: U, b: U) => boolean): U;
+} & S;
+type CreateWithEqualityFn = {
+    <T, Mos extends [StoreMutatorIdentifier, unknown][] = []>(initializer: StateCreator<T, [], Mos>, defaultEqualityFn?: <U>(a: U, b: U) => boolean): UseBoundStoreWithEqualityFn<Mutate<StoreApi<T>, Mos>>;
+    <T>(): <Mos extends [StoreMutatorIdentifier, unknown][] = []>(initializer: StateCreator<T, [], Mos>, defaultEqualityFn?: <U>(a: U, b: U) => boolean) => UseBoundStoreWithEqualityFn<Mutate<StoreApi<T>, Mos>>;
+};
+export declare const createWithEqualityFn: CreateWithEqualityFn;
+export {};

--- a/node_modules/zustand/traditional.js
+++ b/node_modules/zustand/traditional.js
@@ -1,0 +1,29 @@
+'use strict';
+
+var React = require('react');
+var useSyncExternalStoreExports = require('use-sync-external-store/shim/with-selector');
+var vanilla = require('zustand/vanilla');
+
+const { useSyncExternalStoreWithSelector } = useSyncExternalStoreExports;
+const identity = (arg) => arg;
+function useStoreWithEqualityFn(api, selector = identity, equalityFn) {
+  const slice = useSyncExternalStoreWithSelector(
+    api.subscribe,
+    api.getState,
+    api.getInitialState,
+    selector,
+    equalityFn
+  );
+  React.useDebugValue(slice);
+  return slice;
+}
+const createWithEqualityFnImpl = (createState, defaultEqualityFn) => {
+  const api = vanilla.createStore(createState);
+  const useBoundStoreWithEqualityFn = (selector, equalityFn = defaultEqualityFn) => useStoreWithEqualityFn(api, selector, equalityFn);
+  Object.assign(useBoundStoreWithEqualityFn, api);
+  return useBoundStoreWithEqualityFn;
+};
+const createWithEqualityFn = (createState, defaultEqualityFn) => createState ? createWithEqualityFnImpl(createState, defaultEqualityFn) : createWithEqualityFnImpl;
+
+exports.createWithEqualityFn = createWithEqualityFn;
+exports.useStoreWithEqualityFn = useStoreWithEqualityFn;

--- a/node_modules/zustand/vanilla.d.ts
+++ b/node_modules/zustand/vanilla.d.ts
@@ -1,0 +1,31 @@
+type SetStateInternal<T> = {
+    _(partial: T | Partial<T> | {
+        _(state: T): T | Partial<T>;
+    }['_'], replace?: false): void;
+    _(state: T | {
+        _(state: T): T;
+    }['_'], replace: true): void;
+}['_'];
+export interface StoreApi<T> {
+    setState: SetStateInternal<T>;
+    getState: () => T;
+    getInitialState: () => T;
+    subscribe: (listener: (state: T, prevState: T) => void) => () => void;
+}
+export type ExtractState<S> = S extends {
+    getState: () => infer T;
+} ? T : never;
+type Get<T, K, F> = K extends keyof T ? T[K] : F;
+export type Mutate<S, Ms> = number extends Ms['length' & keyof Ms] ? S : Ms extends [] ? S : Ms extends [[infer Mi, infer Ma], ...infer Mrs] ? Mutate<StoreMutators<S, Ma>[Mi & StoreMutatorIdentifier], Mrs> : never;
+export type StateCreator<T, Mis extends [StoreMutatorIdentifier, unknown][] = [], Mos extends [StoreMutatorIdentifier, unknown][] = [], U = T> = ((setState: Get<Mutate<StoreApi<T>, Mis>, 'setState', never>, getState: Get<Mutate<StoreApi<T>, Mis>, 'getState', never>, store: Mutate<StoreApi<T>, Mis>) => U) & {
+    $$storeMutators?: Mos;
+};
+export interface StoreMutators<S, A> {
+}
+export type StoreMutatorIdentifier = keyof StoreMutators<unknown, unknown>;
+type CreateStore = {
+    <T, Mos extends [StoreMutatorIdentifier, unknown][] = []>(initializer: StateCreator<T, [], Mos>): Mutate<StoreApi<T>, Mos>;
+    <T>(): <Mos extends [StoreMutatorIdentifier, unknown][] = []>(initializer: StateCreator<T, [], Mos>) => Mutate<StoreApi<T>, Mos>;
+};
+export declare const createStore: CreateStore;
+export {};

--- a/node_modules/zustand/vanilla.js
+++ b/node_modules/zustand/vanilla.js
@@ -1,0 +1,26 @@
+'use strict';
+
+const createStoreImpl = (createState) => {
+  let state;
+  const listeners = /* @__PURE__ */ new Set();
+  const setState = (partial, replace) => {
+    const nextState = typeof partial === "function" ? partial(state) : partial;
+    if (!Object.is(nextState, state)) {
+      const previousState = state;
+      state = (replace != null ? replace : typeof nextState !== "object" || nextState === null) ? nextState : Object.assign({}, state, nextState);
+      listeners.forEach((listener) => listener(state, previousState));
+    }
+  };
+  const getState = () => state;
+  const getInitialState = () => initialState;
+  const subscribe = (listener) => {
+    listeners.add(listener);
+    return () => listeners.delete(listener);
+  };
+  const api = { setState, getState, getInitialState, subscribe };
+  const initialState = state = createState(setState, getState, api);
+  return api;
+};
+const createStore = (createState) => createState ? createStoreImpl(createState) : createStoreImpl;
+
+exports.createStore = createStore;

--- a/node_modules/zustand/vanilla/shallow.d.ts
+++ b/node_modules/zustand/vanilla/shallow.d.ts
@@ -1,0 +1,1 @@
+export declare function shallow<T>(valueA: T, valueB: T): boolean;

--- a/node_modules/zustand/vanilla/shallow.js
+++ b/node_modules/zustand/vanilla/shallow.js
@@ -1,0 +1,54 @@
+'use strict';
+
+const isIterable = (obj) => Symbol.iterator in obj;
+const hasIterableEntries = (value) => (
+  // HACK: avoid checking entries type
+  "entries" in value
+);
+const compareEntries = (valueA, valueB) => {
+  const mapA = valueA instanceof Map ? valueA : new Map(valueA.entries());
+  const mapB = valueB instanceof Map ? valueB : new Map(valueB.entries());
+  if (mapA.size !== mapB.size) {
+    return false;
+  }
+  for (const [key, value] of mapA) {
+    if (!Object.is(value, mapB.get(key))) {
+      return false;
+    }
+  }
+  return true;
+};
+const compareIterables = (valueA, valueB) => {
+  const iteratorA = valueA[Symbol.iterator]();
+  const iteratorB = valueB[Symbol.iterator]();
+  let nextA = iteratorA.next();
+  let nextB = iteratorB.next();
+  while (!nextA.done && !nextB.done) {
+    if (!Object.is(nextA.value, nextB.value)) {
+      return false;
+    }
+    nextA = iteratorA.next();
+    nextB = iteratorB.next();
+  }
+  return !!nextA.done && !!nextB.done;
+};
+function shallow(valueA, valueB) {
+  if (Object.is(valueA, valueB)) {
+    return true;
+  }
+  if (typeof valueA !== "object" || valueA === null || typeof valueB !== "object" || valueB === null) {
+    return false;
+  }
+  if (!isIterable(valueA) || !isIterable(valueB)) {
+    return compareEntries(
+      { entries: () => Object.entries(valueA) },
+      { entries: () => Object.entries(valueB) }
+    );
+  }
+  if (hasIterableEntries(valueA) && hasIterableEntries(valueB)) {
+    return compareEntries(valueA, valueB);
+  }
+  return compareIterables(valueA, valueB);
+}
+
+exports.shallow = shallow;

--- a/package.json
+++ b/package.json
@@ -1,0 +1,5 @@
+{
+  "dependencies": {
+    "zustand": "^5.0.3"
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,3 +2,7 @@
 # yarn lockfile v1
 
 
+zustand@^5.0.3:
+  version "5.0.3"
+  resolved "https://registry.yarnpkg.com/zustand/-/zustand-5.0.3.tgz#b323435b73d06b2512e93c77239634374b0e407f"
+  integrity sha512-14fwWQtU3pH4dE0dOpdMiWjddcH+QzKIgk1cl8epwSE7yag43k/AD/m4L6+K7DytAOr9gGBe3/EXj9g7cdostg==


### PR DESCRIPTION
## 📖개요
### StartPage.tsx

- [x]  이미지 import → `assets/` 관련 코드 분리
- [ ]  `openUploadingModal` 핸들러 hooks/`useStartPage.ts` 로 옮김
- [ ]  페이지 UI 코드 components/`StartPageContent.tsx` 로 옮김

**정리된 `StartPage.tsx`**

- `Header_login` 컴포넌트 사용
- `useStartPage`에서 핸들러 가져오기
- `StartPageContent`에서 UI 관리

### header_login.tsx

hooks/`useNavigation.ts` 파일을 만들어서 useNavigate와 관련한 이벤트 핸들러를 모아둠.

### Modal.tsx

- `ModalProps`에 가로, 세로, 둥글기 등등을 추가해서 재사용성을 높임.
- React.FC 제거
- ESC키로 모달 닫기 기능 추가함

### ResumeUploadModal.tsx

- `axiosInstance` 적용
- api/`resumeAPI.ts`
    - `uploadResume` : 이력서 업로드 API
    - `startInterview` : 면접 시작 API 분리
- hooks/`useResumeUpload.ts`
    - `handleFileChange` : 파일선택핸들러
        - 말그대로 파일을 선택
    - `handleUploadResume` : 이력서 업로드 핸들러
        - `uploadResume` API를 호출해서 이력서를 업로드 한다.
    - `handleStartInterviewClick` : 면접 시작 핸들러
        - `startInterview` API를 호출해서 면접을 시작함.

### InterviewPage.tsx

→ 이 부분은 코드가 복잡해서 우선 기존 코드 분석부터!

- [x]  zustand로 상태 관리 할 거 → `interviewId`, `socket`, `recording, videoRecording`
    - [x]  `store/useInterviewStore.ts` 생성해서 상태 분리

- [x]  웹소켓 연결, 메시지 수신 및 처리 로직을 `hooks/`로 이동.
    - [x]  `hooks/useWebSocket.ts`로 웹소켓 로직 분리

- [x]  오디오 & 비디오 녹화 관련 로직
    - [ ]  오디오랑 비디오를 분리하는게 좋을 것 같은디이..
        - [x]  `hooks/useAudioRecorder.ts`로 음성 녹음 로직 분리
        - [ ]  `hooks/useVideoRecorder.ts`로 영상 녹화 로직 분리

- [x]  **`InterviewPage.tsx`를 가볍게 유지 →**UI 관련 코드만 남기고, **비즈니스 로직은 `hooks/`, `store/`로 분리**
    - [ ]  마지막으로 `InterviewPage.tsx`에서 정리된 훅만 사용

---

- store/`useInterviewStore.ts`
    - 인터뷰 아이디 : 페이지가 바뀌어도 유지되어야 하는 중요 정보
        - 여러 컴포넌트에서 동일한 ID를 사용해야 하므로 props로 계속 전달하는 것보다 전역에서 관리하는 것이 편해
    - 웹소켓 : 페이지 내 여러 곳에서 데이터를 실시간으로 주고받아야 하는데, 상태를 지역적으로 관리하면 매번 다시 연결해야 함.
        - 웹소켓 연결은 한 번만 열리고, 여러 컴포넌트에서 사용해야 하기 때문에 전역으로 관리하는 것이 효율적
        - 예를 들어, 녹음 중에 웹소켓을 통해 데이터를 전송해야 하는데, **웹소켓 상태가 `InterviewPage.tsx`에만 있으면 녹음 훅(`useMediaRecorder.ts`)에서 접근할 방법이 없음**
    - 녹음 상태를 전역적으로 관리함
        - 녹음이 시작되었는지 여부를 여러 컴포넌트에서 알아야 함.
        - 녹음 중에 화면이 변경되더라도 **상태가 유지**되어야 함.
    - 비디오 녹음 상태도!!
    - 전역 상태를 사용하면 여러 컴포넌트에서 데이터를 공유할 수 있다능
    - Zustand 사용법
        - `create` : Zustand 에서 상태를 정의하는 함수 → 얘가 전역 상태를 만들 준비를 함!!
        - `interface` 에서 관리할 상태의 타입을 정의한다! → 어떤 데이터를 저장할지, 어떤 함수를 제공할지
        - `useInterviewStore` 에서 `create` 로 zustand 상태를 생성해서 업데이트한다. 주로 `set() 함수` 활용!!
        - zustand 상태 사용하기
- hooks/`useWebSocket.ts`
    - 
    

### InterviewHeader.tsx

- `src/hooks/useTimer.ts` : 헤더에 있는 타이머 로직 분리함
- `src/hooks/useUploadInterviewVideo.ts` : 면접 영상 업로드 로직 분리함
<br>

필요시 실행결과 스크린샷 첨부
<br>

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #{이슈넘버}
<br>
<br>

## 💻작업사항

- <br>

## 💡작성한 이슈 외에 작업한 사항

- <br>

## 🩷 Approve 하기 전 확인해주세요!

- [ ] 리뷰어가 확인해줬으면 하는 사항 적어주세요.
- [ ]

<br>

## ✅ 체크리스트

- [ ] PR 제목 규칙 잘 지켰는가?
- [ ] 추가/수정사항을 설명하였는가?
- [ ] 이슈넘버를 적었는가?
